### PR TITLE
Hover info and command completion for Tidal commands

### DIFF
--- a/commands-generated.yaml
+++ b/commands-generated.yaml
@@ -1,0 +1,1696 @@
+## ../tmp/doc-allfunc.txt
+_every:
+    cmd: _every Int -> Int -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        `_every'`
+    links:
+        - https://tidalcycles.org/index.php/_every
+_fast:
+    cmd: _fast Time -> Pattern a -> Pattern a
+    params:
+_run:
+    cmd: _run (Enum a, Num a) => a -> Pattern a
+    params:
+_scan:
+    cmd: _scan (Enum a, Num a) => a -> Pattern a
+    params:
+_slow:
+    cmd: _slow Time -> Pattern a -> Pattern a
+    params:
+append:
+    cmd: append Pattern a -> Pattern a -> Pattern a
+    params:
+cat:
+    cmd: cat [Pattern a] -> Pattern a
+    params:
+compress:
+    cmd: compress Arc -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/compress
+compressTo:
+    cmd: compressTo Arc -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/compressTo
+cosine:
+    cmd: cosine Fractional a => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cosine
+density:
+    cmd: density Pattern Time -> Pattern a -> Pattern a
+    params:
+densityGap:
+    cmd: densityGap Pattern Time -> Pattern a -> Pattern a
+    params:
+envEq:
+    cmd: envEq Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/envEq
+envEqR:
+    cmd: envEqR Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/envEqR
+envL:
+    cmd: envL Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/envL
+envLR:
+    cmd: envLR Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/envLR
+every:
+    cmd: every Pattern Int -> Pattern Int -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        `every'`
+    links:
+        - https://tidalcycles.org/index.php/every
+fast:
+    cmd: fast Pattern Time -> Pattern a -> Pattern a
+    params:
+fastAppend:
+    cmd: fastAppend Pattern a -> Pattern a -> Pattern a
+    params:
+fastCat:
+    cmd: fastCat [Pattern a] -> Pattern a
+    params:
+fastFromList:
+    cmd: fastFromList [a] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fastFromList
+fastGap:
+    cmd: fastGap Pattern Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fastGap
+fastRepeatCycles:
+    cmd: fastRepeatCycles Int -> Pattern a -> Pattern a
+    params:
+fastSqueeze:
+    cmd: fastSqueeze Pattern Time -> Pattern a -> Pattern a
+    params:
+fastcat:
+    cmd: fastcat [Pattern a] -> Pattern a
+    params:
+foldEvery:
+    cmd: foldEvery [Int] -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+fromList:
+    cmd: fromList [a] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fromList
+fromMaybes:
+    cmd: fromMaybes [Maybe a] -> Pattern a
+    params:
+isaw:
+    cmd: isaw (Fractional a, Real a) => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/isaw
+listToPat:
+    cmd: listToPat [a] -> Pattern a
+    params:
+overlay:
+    cmd: overlay Pattern a -> Pattern a -> Pattern a
+    params:
+repeatCycles:
+    cmd: repeatCycles Int -> Pattern a -> Pattern a
+    params:
+rev:
+    cmd: rev Pattern a -> Pattern a
+    params:
+run:
+    cmd: run (Enum a, Num a) => Pattern a -> Pattern a
+    params:
+saw:
+    cmd: saw (Fractional a, Real a) => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/saw
+scan:
+    cmd: scan (Enum a, Num a) => Pattern a -> Pattern a
+    params:
+sig:
+    cmd: sig (Time -> a) -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/sig
+silence:
+    cmd: silence Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/silence
+sine:
+    cmd: sine Fractional a => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/sine
+slow:
+    cmd: slow Pattern Time -> Pattern a -> Pattern a
+    params:
+slowAppend:
+    cmd: slowAppend Pattern a -> Pattern a -> Pattern a
+    params:
+slowCat:
+    cmd: slowCat [Pattern a] -> Pattern a
+    params:
+slowSqueeze:
+    cmd: slowSqueeze Pattern Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/slowSqueeze
+slowcat:
+    cmd: slowcat [Pattern a] -> Pattern a
+    params:
+sparsity:
+    cmd: sparsity Pattern Time -> Pattern a -> Pattern a
+    params:
+square:
+    cmd: square (Fractional a, Real a) => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/square
+stack:
+    cmd: stack [Pattern a] -> Pattern a
+    params:
+timeCat:
+    cmd: timeCat [(Time, Pattern a)] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/timeCat
+tri:
+    cmd: tri (Fractional a, Real a) => Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/tri
+when:
+    cmd: when (Int -> Bool) -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+whenT:
+    cmd: whenT (Time -> Bool) -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/whenT
+zoom:
+    cmd: zoom Pattern Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        <nowiki>|%</nowiki>
+        <nowiki>|%|</nowiki>
+        <nowiki>|*</nowiki>
+        <nowiki>|*|</nowiki>
+        <nowiki>|+</nowiki>
+        <nowiki>|+|</nowiki>
+        <nowiki>|-</nowiki>
+        <nowiki>|-|</nowiki>
+        <nowiki>|/</nowiki>
+        <nowiki>|/|</nowiki>
+        <nowiki>|<</nowiki>
+        <nowiki>|<|</nowiki>
+        <nowiki>|></nowiki>
+        <nowiki>|>|</nowiki>
+        <nowiki>~></nowiki>
+    links:
+        - https://tidalcycles.org/index.php/zoom
+_cF:
+    cmd: _cF [Double] -> String -> Pattern Double
+    params:
+_cP:
+    cmd: _cP (Enumerable a, Parseable a) => [Pattern a] -> String -> Pattern a
+    params:
+_cS:
+    cmd: _cS [String] -> String -> Pattern String
+    params:
+_cX:
+    cmd: _cX (Arc -> Value -> [Event a]) -> [a] -> String -> Pattern a
+    params:
+_chop:
+    cmd: _chop Int -> ControlPattern -> ControlPattern
+    params:
+_gap:
+    cmd: _gap Int -> ControlPattern -> ControlPattern
+    params:
+_slice:
+    cmd: _slice Int -> Int -> ControlPattern -> ControlPattern
+    params:
+_spin:
+    cmd: _spin Int -> ControlPattern -> ControlPattern
+    params:
+_striate:
+    cmd: _striate Int -> ControlPattern -> ControlPattern
+    params:
+_striateBy:
+    cmd: _striateBy Int -> Double -> ControlPattern -> ControlPattern
+    params:
+_stut:
+    cmd: _stut Integer -> Double -> Rational -> ControlPattern -> ControlPattern
+    params:
+_stutWith:
+    cmd: _stutWith (Num n, Ord n) => n -> Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+cF:
+    cmd: cF Double -> String -> Pattern Double
+    params:
+cF0:
+    cmd: cF0 String -> Pattern Double
+    params:
+cF_:
+    cmd: cF_ String -> Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cF_
+cI:
+    cmd: cI String -> Pattern Int
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cI
+cP:
+    cmd: cP (Enumerable a, Parseable a) => Pattern a -> String -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cP
+cP_:
+    cmd: cP_ (Enumerable a, Parseable a) => String -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cP_
+cR:
+    cmd: cR Time -> String -> Pattern Rational
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cR
+cR0:
+    cmd: cR0 String -> Pattern Time
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cR0
+cR_:
+    cmd: cR_ String -> Pattern Time
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cR_
+cS:
+    cmd: cS String -> String -> Pattern String
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cS
+cS_:
+    cmd: cS_ String -> Pattern String
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cS_
+cT:
+    cmd: cT Time -> String -> Pattern Time
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cT
+cT0:
+    cmd: cT0 String -> Pattern Time
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cT0
+cT_:
+    cmd: cT_ String -> Pattern Time
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cT_
+chop:
+    cmd: chop Pattern Int -> ControlPattern -> ControlPattern
+    params:
+chopArc:
+    cmd: chopArc Arc -> Int -> [Arc]
+    params:
+gap:
+    cmd: gap Pattern Int -> ControlPattern -> ControlPattern
+    params:
+hurry:
+    cmd: hurry Pattern Rational -> ControlPattern -> ControlPattern
+    params:
+in0:
+    cmd: in0 Pattern Double
+    params:
+in1:
+    cmd: in1 Pattern Double
+    params:
+    help: |
+        TODO
+        ... up to ...
+    links:
+        - https://tidalcycles.org/index.php/in1
+in127:
+    cmd: in127 Pattern Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/in127
+interlace:
+    cmd: interlace ControlPattern -> ControlPattern -> ControlPattern
+    params:
+loopAt:
+    cmd: loopAt Pattern Time -> ControlPattern -> ControlPattern
+    params:
+mergePlayRange:
+    cmd: mergePlayRange (Double, Double) -> ControlMap -> ControlMap
+    params:
+randslice:
+    cmd: randslice Int -> ControlPattern -> ControlPattern
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/randslice
+slice:
+    cmd: slice Pattern Int -> Pattern Int -> ControlPattern -> ControlPattern
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/slice
+smash:
+    cmd: smash Int -> [Pattern Time] -> ControlPattern -> Pattern ControlMap
+    params:
+    help: |
+        `smash'`
+    links:
+        - https://tidalcycles.org/index.php/smash
+spin:
+    cmd: spin Pattern Int -> ControlPattern -> ControlPattern
+    params:
+striate:
+    cmd: striate Pattern Int -> Pattern Double -> ControlPattern -> ControlPattern
+    params:
+    help: |
+        `striate'`
+    links:
+        - https://tidalcycles.org/index.php/striate
+striateBy:
+    cmd: striateBy Pattern Int -> Pattern Double -> ControlPattern -> ControlPattern
+    params:
+stut:
+    cmd: stut Pattern Int -> Pattern Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        `stut'`
+    links:
+        - https://tidalcycles.org/index.php/stut
+stutWith:
+    cmd: stutWith Pattern Int -> Pattern Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+weave:
+    cmd: weave Time -> Pattern a -> [Pattern a -> Pattern a] -> Pattern a
+    params:
+    help: |
+        `weave'`
+    links:
+        - https://tidalcycles.org/index.php/weave
+weaveWith:
+    cmd: weaveWith Time -> Pattern a -> [Pattern a -> Pattern a] -> Pattern a
+    params:
+_degradeBy:
+    cmd: _degradeBy Double -> Pattern a -> Pattern a
+    params:
+_distrib:
+    cmd: _distrib [Int] -> Pattern a -> Pattern a
+    params:
+_euclid:
+    cmd: _euclid Int -> Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        `_euclid'`
+    links:
+        - https://tidalcycles.org/index.php/_euclid
+_euclidBool:
+    cmd: _euclidBool Int -> Int -> Pattern Bool
+    params:
+_euclidFull:
+    cmd: _euclidFull Int -> Int -> Pattern a -> Pattern a -> Pattern a
+    params:
+_euclidInv:
+    cmd: _euclidInv Int -> Int -> Pattern a -> Pattern a
+    params:
+_euclidOff:
+    cmd: _euclidOff Int -> Int -> Integer -> Pattern a -> Pattern a
+    params:
+_euclidOffBool:
+    cmd: _euclidOffBool Int -> Int -> Integer -> Pattern Bool -> Pattern Bool
+    params:
+_iter:
+    cmd: _iter Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        `_iter'`
+    links:
+        - https://tidalcycles.org/index.php/_iter
+_linger:
+    cmd: _linger Time -> Pattern a -> Pattern a
+    params:
+_off:
+    cmd: _off Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+_ply:
+    cmd: _ply Int -> Pattern a -> Pattern a
+    params:
+_range:
+    cmd: _range (Functor f, Num b) => b -> b -> f b -> f b
+    params:
+_rot:
+    cmd: _rot Ord a => Int -> Pattern a -> Pattern a
+    params:
+_segment:
+    cmd: _segment Time -> Pattern a -> Pattern a
+    params:
+_select:
+    cmd: _select Double -> [Pattern a] -> Pattern a
+    params:
+_stripe:
+    cmd: _stripe Int -> Pattern a -> Pattern a
+    params:
+_trunc:
+    cmd: _trunc Time -> Pattern a -> Pattern a
+    params:
+_unDegradeBy:
+    cmd: _unDegradeBy Double -> Pattern a -> Pattern a
+    params:
+almostAlways:
+    cmd: almostAlways (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+almostNever:
+    cmd: almostNever (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+always:
+    cmd: always (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+arpeggiate:
+    cmd: arpeggiate Pattern a -> Pattern a
+    params:
+arpg:
+    cmd: arpg Pattern a -> Pattern a
+    params:
+brak:
+    cmd: brak Pattern a -> Pattern a
+    params:
+choose:
+    cmd: choose [a] -> Pattern a
+    params:
+chooseBy:
+    cmd: chooseBy Pattern Double -> [a] -> Pattern a
+    params:
+chunk:
+    cmd: chunk Integral a => a -> (Pattern b -> Pattern b) -> Pattern b -> Pattern b
+    params:
+    help: |
+        TODO
+        `chunk'`
+    links:
+        - https://tidalcycles.org/index.php/chunk
+contrast:
+    cmd: contrast (ControlPattern -> ControlPattern) -> (ControlPattern -> ControlPattern) -> ControlPattern -> ControlPattern -> ControlPattern
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/contrast
+contrastBy:
+    cmd: contrastBy (a -> Value -> Bool) -> (ControlPattern -> Pattern b) -> (ControlPattern -> Pattern b) -> Pattern (containers-0.5.7.1:Data.Map.Base.Map String a) -> Pattern (containers-0.5.7.1:Data.Map.Base.Map String Value) -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/contrastBy
+contrastRange:
+    cmd: contrastRange (ControlPattern -> Pattern a) -> (ControlPattern -> Pattern a) -> Pattern (containers-0.5.7.1:Data.Map.Base.Map String (Value, Value)) -> ControlPattern -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/contrastRange
+cycleChoose:
+    cmd: cycleChoose [a] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/cycleChoose
+degrade:
+    cmd: degrade Pattern a -> Pattern a
+    params:
+degradeBy:
+    cmd: degradeBy Pattern Double -> Pattern a -> Pattern a
+    params:
+degradeOverBy:
+    cmd: degradeOverBy Int -> Pattern Double -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/degradeOverBy
+discretise:
+    cmd: discretise Pattern Time -> Pattern a -> Pattern a
+    params:
+distrib:
+    cmd: distrib [Pattern Int] -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/distrib
+double:
+    cmd: double Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/double
+echo:
+    cmd: echo Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/echo
+enclosingArc:
+    cmd: enclosingArc [Arc] -> Arc
+    params:
+euclid:
+    cmd: euclid Pattern Int -> Pattern Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/euclid
+euclidFull:
+    cmd: euclidFull Pattern Int -> Pattern Int -> Pattern a -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/euclidFull
+euclidInv:
+    cmd: euclidInv Pattern Int -> Pattern Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/euclidInv
+euclidOff:
+    cmd: euclidOff Pattern Int -> Pattern Int -> Pattern Integer -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/euclidOff
+euclidOffBool:
+    cmd: euclidOffBool Pattern Int -> Pattern Int -> Pattern Integer -> Pattern Bool -> Pattern Bool
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/euclidOffBool
+fadeIn:
+    cmd: fadeIn Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fadeIn
+fadeInFrom:
+    cmd: fadeInFrom Time -> Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fadeInFrom
+fadeOut:
+    cmd: fadeOut Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fadeOut
+fadeOutFrom:
+    cmd: fadeOutFrom Time -> Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fadeOutFrom
+fastspread:
+    cmd: fastspread (a -> t -> Pattern b) -> [a] -> t -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fastspread
+fit:
+    cmd: fit Pattern Time -> Int -> Pattern Int -> Pattern Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        `fit'`
+    links:
+        - https://tidalcycles.org/index.php/fit
+fix:
+    cmd: fix (ControlPattern -> ControlPattern) -> ControlPattern -> ControlPattern -> ControlPattern
+    params:
+fixRange:
+    cmd: fixRange (ControlPattern -> Pattern ControlMap) -> Pattern (containers-0.5.7.1:Data.Map.Base.Map String (Value, Value)) -> ControlPattern -> Pattern ControlMap
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/fixRange
+flatpat:
+    cmd: flatpat Pattern [a] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/flatpat
+ghost:
+    cmd: ghost Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+        `ghost'`
+        `ghost''`
+    links:
+        - https://tidalcycles.org/index.php/ghost
+ifp:
+    cmd: ifp (Int -> Bool) -> (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+index:
+    cmd: index Real b => b -> Pattern b -> Pattern c -> Pattern c
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/index
+inhabit:
+    cmd: inhabit [(String, Pattern a)] -> Pattern String -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/inhabit
+inside:
+    cmd: inside Pattern Time -> (Pattern a1 -> Pattern a) -> Pattern a1 -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/inside
+inv:
+    cmd: inv Functor f => f Bool -> f Bool
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/inv
+irand:
+    cmd: irand Num a => Int -> Pattern a
+    params:
+iter:
+    cmd: iter Pattern Int -> Pattern c -> Pattern c
+    params:
+    help: |
+        `iter'`
+    links:
+        - https://tidalcycles.org/index.php/iter
+jux:
+    cmd: jux [t -> Pattern ControlMap] -> t -> Pattern ControlMap
+    params:
+    help: |
+        `jux'`
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/jux
+jux4:
+    cmd: jux4 (Pattern ControlMap -> Pattern ControlMap) -> Pattern ControlMap -> Pattern ControlMap
+    params:
+    help: |
+        remove?
+    links:
+        - https://tidalcycles.org/index.php/jux4
+juxBy:
+    cmd: juxBy Pattern Double -> (Pattern ControlMap -> Pattern ControlMap) -> Pattern ControlMap -> Pattern ControlMap
+    params:
+juxcut:
+    cmd: juxcut [t -> Pattern ControlMap] -> t -> Pattern ControlMap
+    params:
+    help: |
+        TODO
+        `juxcut'`
+    links:
+        - https://tidalcycles.org/index.php/juxcut
+layer:
+    cmd: layer [a -> Pattern b] -> a -> Pattern b
+    params:
+lindenmayer:
+    cmd: lindenmayer Int -> String -> String -> String
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/lindenmayer
+lindenmayerI:
+    cmd: lindenmayerI Num b => Int -> String -> String -> [b]
+    params:
+linger:
+    cmd: linger Pattern Time -> Pattern a -> Pattern a
+    params:
+loopFirst:
+    cmd: loopFirst Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/loopFirst
+mask:
+    cmd: mask Pattern Bool -> Pattern a -> Pattern a
+    params:
+never:
+    cmd: never (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+off:
+    cmd: off Pattern Time -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/off
+offadd:
+    cmd: offadd Num a => Pattern Time -> Pattern a -> Pattern a -> Pattern a
+    params:
+    help: |
+        deprecate?
+    links:
+        - https://tidalcycles.org/index.php/offadd
+often:
+    cmd: often (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+outside:
+    cmd: outside Pattern Time -> (Pattern a1 -> Pattern a) -> Pattern a1 -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/outside
+palindrome:
+    cmd: palindrome Pattern a -> Pattern a
+    params:
+parseLMRule:
+    cmd: parseLMRule String -> [(Char, String)]
+    params:
+    help: |
+        TODO
+        `parseLMRule'`
+    links:
+        - https://tidalcycles.org/index.php/parseLMRule
+permstep:
+    cmd: permstep RealFrac b => Int -> [a] -> Pattern b -> Pattern a
+    params:
+pick:
+    cmd: pick String -> Int -> String
+    params:
+    help: |
+        deprecate?
+    links:
+        - https://tidalcycles.org/index.php/pick
+ply:
+    cmd: ply Pattern Int -> Pattern a -> Pattern a
+    params:
+quad:
+    cmd: quad Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/quad
+quantise:
+    cmd: quantise (Functor f, RealFrac b) => b -> f b -> f b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/quantise
+rand:
+    cmd: rand Fractional a => Pattern a
+    params:
+randArcs:
+    cmd: randArcs Int -> Pattern [Arc]
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/randArcs
+randStruct:
+    cmd: randStruct Int -> Pattern Int
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/randStruct
+randcat:
+    cmd: randcat [Pattern a] -> Pattern a
+    params:
+range:
+    cmd: range Num a => Pattern a -> Pattern a -> Pattern a -> Pattern a
+    params:
+rangex:
+    cmd: rangex (Functor f, Floating b) => b -> b -> f b -> f b
+    params:
+rarely:
+    cmd: rarely (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+revArc:
+    cmd: revArc Arc -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/revArc
+rot:
+    cmd: rot Ord a => Pattern Int -> Pattern a -> Pattern a
+    params:
+runWith:
+    cmd: runWith Integral a => a -> (Pattern b -> Pattern b) -> Pattern b -> Pattern b
+    params:
+    help: |
+        TODO
+        `runWith'`
+    links:
+        - https://tidalcycles.org/index.php/runWith
+samples:
+    cmd: samples Applicative f => f String -> f Int -> f String
+    params:
+    help: |
+        deprecate?
+        `samples'`
+    links:
+        - https://tidalcycles.org/index.php/samples
+scramble:
+    cmd: scramble Int -> Pattern a -> Pattern a
+    params:
+segment:
+    cmd: segment Pattern Time -> Pattern a -> Pattern a
+    params:
+select:
+    cmd: select Pattern Double -> [Pattern a] -> Pattern a
+    params:
+seqP:
+    cmd: seqP [(Time, Time, Pattern a)] -> Pattern a
+    params:
+seqPLoop:
+    cmd: seqPLoop [(Time, Time, Pattern a)] -> Pattern a
+    params:
+sew:
+    cmd: sew Pattern Bool -> Pattern a -> Pattern a -> Pattern a
+    params:
+shuffle:
+    cmd: shuffle Int -> Pattern a -> Pattern a
+    params:
+slowspread:
+    cmd: slowspread (a -> t -> Pattern b) -> [a] -> t -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/slowspread
+slowstripe:
+    cmd: slowstripe Pattern Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/slowstripe
+someCycles:
+    cmd: someCycles (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+someCyclesBy:
+    cmd: someCyclesBy Double -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+somecycles:
+    cmd: somecycles (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+somecyclesBy:
+    cmd: somecyclesBy Double -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+sometimes:
+    cmd: sometimes (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+sometimesBy:
+    cmd: sometimesBy Pattern Double -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+spaceOut:
+    cmd: spaceOut [Time] -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/spaceOut
+spread:
+    cmd: spread Monad m => (a -> b -> m c) -> m a -> b -> m c
+    params:
+    help: |
+        TODO
+        `spread'`
+    links:
+        - https://tidalcycles.org/index.php/spread
+spreadChoose:
+    cmd: spreadChoose (t -> t1 -> Pattern b) -> [t] -> t1 -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/spreadChoose
+spreadf:
+    cmd: spreadf [a -> Pattern b] -> a -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/spreadf
+spreadr:
+    cmd: spreadr (t -> t1 -> Pattern b) -> [t] -> t1 -> Pattern b
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/spreadr
+stackwith:
+    cmd: stackwith Sound.Tidal.Context.Unionable a => Pattern a -> [Pattern a] -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/stackwith
+step:
+    cmd: step [String] -> String -> Pattern String
+    params:
+    help: |
+        TODO
+        `step'`
+    links:
+        - https://tidalcycles.org/index.php/step
+steps:
+    cmd: steps [(String, String)] -> Pattern String
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/steps
+stretch:
+    cmd: stretch Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/stretch
+stripe:
+    cmd: stripe Pattern Int -> Pattern a -> Pattern a
+    params:
+struct:
+    cmd: struct Pattern Bool -> Pattern a -> Pattern a
+    params:
+stutter:
+    cmd: stutter Integral i => i -> Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/stutter
+substruct:
+    cmd: substruct Pattern Int -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+        `substruct'`
+    links:
+        - https://tidalcycles.org/index.php/substruct
+superimpose:
+    cmd: superimpose (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+swing:
+    cmd: swing Pattern Time -> Pattern a -> Pattern a
+    params:
+swingBy:
+    cmd: swingBy Pattern Time -> Pattern Time -> Pattern a -> Pattern a
+    params:
+tabby:
+    cmd: tabby Integer -> Pattern a -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/tabby
+timeLoop:
+    cmd: timeLoop Pattern Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/timeLoop
+timeToRand:
+    cmd: timeToRand RealFrac a => a -> Double
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/timeToRand
+toScale:
+    cmd: toScale Num a => Int -> [a] -> Pattern Int -> Pattern a
+    params:
+    help: |
+        TODO
+        `toScale'`
+    links:
+        - https://tidalcycles.org/index.php/toScale
+triple:
+    cmd: triple Time -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/triple
+trunc:
+    cmd: trunc Pattern Time -> Pattern a -> Pattern a
+    params:
+unDegradeBy:
+    cmd: unDegradeBy Pattern Double -> Pattern a -> Pattern a
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/unDegradeBy
+unfix:
+    cmd: unfix (ControlPattern -> ControlPattern) -> ControlPattern -> ControlPattern -> ControlPattern
+    params:
+    help: |
+        TODO
+    links:
+        - https://tidalcycles.org/index.php/unfix
+unfixRange:
+    cmd: unfixRange Pattern (Pattern a) -> Pattern a
+    params:
+    help: |
+        TODO
+        `unwrap'`
+    links:
+        - https://tidalcycles.org/index.php/unfixRange
+ur:
+    cmd: ur Time -> Pattern String -> [(String, Pattern a)] -> [(String, Pattern a -> Pattern a)] -> Pattern a
+    params:
+wchoose:
+    cmd: wchoose [(a, Double)] -> Pattern a
+    params:
+wchooseBy:
+    cmd: wchooseBy Pattern Double -> [(a, Double)] -> Pattern a
+    params:
+wedge:
+    cmd: wedge Time -> Pattern a -> Pattern a -> Pattern a
+    params:
+whenmod:
+    cmd: whenmod Int -> Int -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+    params:
+within:
+    cmd: within Pattern (a -> b) -> Pattern a -> Pattern b
+    params:
+    help: |
+        `within'`
+    links:
+        - https://tidalcycles.org/index.php/within
+__compress:
+    cmd: __compress Arc -> Pattern a -> Pattern a
+    params:
+__compressTo:
+    cmd: __compressTo Arc -> Pattern a -> Pattern a
+    params:
+_fastGap:
+    cmd: _fastGap Time -> Pattern a -> Pattern a
+    params:
+applyFIS:
+    cmd: applyFIS (Double -> Double) -> (Int -> Int) -> (String -> String) -> Value -> Value
+    params:
+arcCycles:
+    cmd: arcCycles Arc -> [Arc]
+    params:
+arcCyclesZW:
+    cmd: arcCyclesZW Arc -> [Arc]
+    params:
+compareDefrag:
+    cmd: compareDefrag (Eq a, Ord a) => [Event a] -> [Event a] -> Bool
+    params:
+cycleArcsInArc:
+    cmd: cycleArcsInArc Arc -> [Arc]
+    params:
+cyclePos:
+    cmd: cyclePos Time -> Time
+    params:
+cyclesInArc:
+    cmd: cyclesInArc Integral a => Arc -> [a]
+    params:
+defragParts:
+    cmd: defragParts Eq a => [Event a] -> [Event a]
+    params:
+empty:
+    cmd: empty Pattern a
+    params:
+eventHasOnset:
+    cmd: eventHasOnset Event a -> Bool
+    params:
+eventPart:
+    cmd: eventPart Event a -> Arc
+    params:
+eventValue:
+    cmd: eventValue Event a -> a
+    params:
+eventWhole:
+    cmd: eventWhole Event a -> Arc
+    params:
+eventWholeOnset:
+    cmd: eventWholeOnset Event a -> Time
+    params:
+fNum2:
+    cmd: fNum2 (Int -> Int -> Int) -> (Double -> Double -> Double) -> Value -> Value -> Value
+    params:
+filterJust:
+    cmd: filterJust Pattern (Maybe a) -> Pattern a
+    params:
+filterValues:
+    cmd: filterValues (a -> Bool) -> Pattern a -> Pattern a
+    params:
+filterWhen:
+    cmd: filterWhen (Time -> Bool) -> Pattern a -> Pattern a
+    params:
+getF:
+    cmd: getF Value -> Maybe Double
+    params:
+getI:
+    cmd: getI Value -> Maybe Int
+    params:
+getS:
+    cmd: getS Value -> Maybe String
+    params:
+innerJoin:
+    cmd: innerJoin Pattern (Pattern a) -> Pattern a
+    params:
+isAdjacent:
+    cmd: isAdjacent Eq a => Event a -> Event a -> Bool
+    params:
+isAnalog:
+    cmd: isAnalog Pattern a -> Bool
+    params:
+isDigital:
+    cmd: isDigital Pattern a -> Bool
+    params:
+isIn:
+    cmd: isIn Arc -> Time -> Bool
+    params:
+mapArc:
+    cmd: mapArc (Time -> Time) -> Arc -> Arc
+    params:
+mapCycle:
+    cmd: mapCycle (Time -> Time) -> Arc -> Arc
+    params:
+matchManyToOne:
+    cmd: matchManyToOne
+    help: |
+        ``  (b -> a -> Bool) -> Pattern a -> Pattern b -> Pattern (Bool, b)
+    links:
+        - https://tidalcycles.org/index.php/matchManyToOne
+nextSam:
+    cmd: nextSam Time -> Time
+    params:
+noOv:
+    cmd: noOv String -> a
+    params:
+onsetIn:
+    cmd: onsetIn Arc -> Event a -> Bool
+    params:
+outerJoin:
+    cmd: outerJoin Pattern (Pattern a) -> Pattern a
+    params:
+playFor:
+    cmd: playFor Time -> Time -> Pattern a -> Pattern a
+    params:
+prettyRat:
+    cmd: prettyRat Rational -> String
+    params:
+queryArc:
+    cmd: queryArc Pattern a -> Arc -> [Event a]
+    params:
+rotL:
+    cmd: rotL Time -> Pattern a -> Pattern a
+    params:
+rotR:
+    cmd: rotR Time -> Pattern a -> Pattern a
+    params:
+sam:
+    cmd: sam Time -> Time
+    params:
+showFrac:
+    cmd: showFrac Integer -> Integer -> String
+    params:
+showPattern:
+    cmd: showPattern Show a => Arc -> Pattern a -> String
+    params:
+splitQueries:
+    cmd: splitQueries Pattern a -> Pattern a
+    params:
+subArc:
+    cmd: subArc Arc -> Arc -> Maybe Arc
+    params:
+tParam:
+    cmd: tParam (t1 -> t2 -> Pattern a) -> Pattern t1 -> t2 -> Pattern a
+    params:
+tParam2:
+    cmd: tParam2 (a -> b -> c -> Pattern d) -> Pattern a -> Pattern b -> c -> Pattern d
+    params:
+tParam3:
+    cmd: tParam3 (a -> b -> c -> Pattern d -> Pattern e) -> Pattern a -> Pattern b -> Pattern c -> Pattern d -> Pattern e
+    params:
+tParamSqueeze:
+    cmd: tParamSqueeze (a -> Pattern b -> Pattern c) -> Pattern a -> Pattern b -> Pattern c
+    params:
+timeToCycleArc:
+    cmd: timeToCycleArc Time -> Arc
+    params:
+toTime:
+    cmd: toTime Real a => a -> Rational
+    params:
+unwrap:
+    cmd: unwrap Pattern (Pattern a) -> Pattern a
+    params:
+unwrapSqueeze:
+    cmd: unwrapSqueeze Pattern (Pattern a) -> Pattern a
+    params:
+withEvent:
+    cmd: withEvent (Event a -> Event b) -> Pattern a -> Pattern b
+    params:
+withEvents:
+    cmd: withEvents ([Event a] -> [Event b]) -> Pattern a -> Pattern b
+    params:
+withPart:
+    cmd: withPart (Arc -> Arc) -> Pattern a -> Pattern a
+    params:
+withQueryArc:
+    cmd: withQueryArc (Arc -> Arc) -> Pattern a -> Pattern a
+    params:
+withQueryTime:
+    cmd: withQueryTime (Time -> Time) -> Pattern a -> Pattern a
+    params:
+withResultArc:
+    cmd: withResultArc (Arc -> Arc) -> Pattern a -> Pattern a
+    params:
+withResultTime:
+    cmd: withResultTime (Time -> Time) -> Pattern a -> Pattern a
+    params:
+## ../tmp/doc-control.txt
+s:
+    cmd: s Pattern String
+    params:
+    help: |
+        An alias of `sound`
+    links:
+        - https://tidalcycles.org/index.php/s
+n:
+    cmd: n Pattern Double
+    params:
+sound:
+    cmd: sound Pattern String
+    params:
+    help: |
+        Sounds - either sample sets or synth names. This control is *required* when triggering sounds via SuperDirt.
+    links:
+        - https://tidalcycles.org/index.php/sound
+begin:
+    cmd: begin Pattern Double
+    params:
+    help: |
+        Starts sample playback some fraction from the beginning. 0.5 would start playback at the middle.
+    links:
+        - https://tidalcycles.org/index.php/begin
+end:
+    cmd: end Pattern Double
+    params:
+    help: |
+        Stops sample playback some fraction from the end. 0.5 would stop playback at the middle.
+    links:
+        - https://tidalcycles.org/index.php/end
+accelerate:
+    cmd: accelerate Pattern Double
+    params:
+    help: |
+        Speeds up (or slows down) samples while they play.
+    links:
+        - https://tidalcycles.org/index.php/accelerate
+cps:
+    cmd: cps Pattern Double
+    params:
+nudge:
+    cmd: nudge Pattern Double
+    params:
+unit:
+    cmd: unit Pattern String
+    params:
+loop:
+    cmd: loop Pattern Double
+    params:
+    help: |
+        Specifies how many times to loop through the sample.
+    links:
+        - https://tidalcycles.org/index.php/loop
+legato:
+    cmd: legato Pattern Double
+    params:
+sustain:
+    cmd: sustain Pattern Double
+    params:
+gain:
+    cmd: gain Pattern Double
+    params:
+    help: |
+        Specifies volume. Values less than 1 make the sound quieter. Values greater than 1 make the sound louder.
+    links:
+        - https://tidalcycles.org/index.php/gain
+channel:
+    cmd: channel Pattern Int
+    params:
+pan:
+    cmd: pan Pattern Double
+    params:
+    help: |
+        Controls stereo position for playback. With the default two-channel setup, zero is left, one is right.
+    links:
+        - https://tidalcycles.org/index.php/pan
+note:
+    cmd: note Pattern Double
+    params:
+freq:
+    cmd: freq Pattern Double
+    params:
+midinote:
+    cmd: midinote Pattern Double
+    params:
+octave:
+    cmd: octave Pattern Int
+    params:
+    help: |
+        Sets where "middle" C is. Default is 5, so "n 0" corresponds to "midinote 60"
+    links:
+        - https://tidalcycles.org/index.php/octave
+offset:
+    cmd: offset Pattern Double
+    params:
+cut:
+    cmd: cut Pattern Int
+    params:
+orbit:
+    cmd: orbit Pattern Int
+    params:
+shape:
+    cmd: shape Pattern Double
+    params:
+    help: |
+        Distorts the sound, has a maximum value of 1.
+    links:
+        - https://tidalcycles.org/index.php/shape
+hcutoff:
+    cmd: hcutoff Pattern Double
+    params:
+    help: |
+        Frequency in Hz for a high-pass filter.  Alias is "hpf".
+    links:
+        - https://tidalcycles.org/index.php/hcutoff
+hresonance:
+    cmd: hresonance Pattern Double
+    params:
+    help: |
+        Resonance for high-pass filter.  Alias is "hpq".
+    links:
+        - https://tidalcycles.org/index.php/hresonance
+bandf:
+    cmd: bandf Pattern Double
+    params:
+bandq:
+    cmd: bandq Pattern Double
+    params:
+crush:
+    cmd: crush Pattern Double
+    params:
+coarse:
+    cmd: coarse Pattern Int
+    params:
+cutoff:
+    cmd: cutoff Pattern Double
+    params:
+attack:
+    cmd: attack Pattern Double
+    params:
+release:
+    cmd: release Pattern Double
+    params:
+hold:
+    cmd: hold Pattern Double
+    params:
+tremolorate:
+    cmd: tremolorate Pattern Double
+    params:
+tremolodepth:
+    cmd: tremolodepth Pattern Double
+    params:
+phaserrate:
+    cmd: phaserrate Pattern Double
+    params:
+phaserdepth:
+    cmd: phaserdepth Pattern Double
+    params:
+vowel:
+    cmd: vowel Pattern String
+    params:
+delaytime:
+    cmd: delaytime Pattern Double
+    params:
+delayfeedback:
+    cmd: delayfeedback Pattern Double
+    params:
+delayAmp:
+    cmd: delayAmp Pattern Double
+    params:
+    help: |
+        ''missing from params?''
+    links:
+        - https://tidalcycles.org/index.php/delayAmp
+delaySend:
+    cmd: delaySend Pattern Double
+    params:
+    help: |
+        ''missing from params?''
+    links:
+        - https://tidalcycles.org/index.php/delaySend
+lock:
+    cmd: lock Pattern Double
+    params:
+    help: |
+        1 to lock delay to cycles per second (cps) aka tempo sync so with `\# lock 1 \# delayt 0.25` = 1/4 of cycle delay etc
+    links:
+        - https://tidalcycles.org/index.php/lock
+size:
+    cmd: size Pattern Double
+    params:
+room:
+    cmd: room Pattern Double
+    params:
+dry:
+    cmd: dry Pattern Double
+    params:
+leslie:
+    cmd: leslie Pattern Double
+    params:
+lrate:
+    cmd: lrate Pattern Double
+    params:
+lsize:
+    cmd: lsize Pattern Double
+    params:
+waveloss:
+    cmd: waveloss Pattern Double
+    params:
+    help: |
+        Drops samples n out of 100.
+    links:
+        - https://tidalcycles.org/index.php/waveloss
+squiz:
+    cmd: squiz Pattern Double
+    params:
+    help: |
+        A weird pitch-shifter. Accepts numbers over 1.
+    links:
+        - https://tidalcycles.org/index.php/squiz
+## ../tmp/doc-transitions.txt
+anticipate:
+    cmd: anticipate Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        An increasing comb filter.
+    links:
+        - https://tidalcycles.org/index.php/anticipate
+anticipateIn:
+    cmd: anticipateIn Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Same as anticipate though it allows you to specify the number of cycles until dropping to the new pattern.
+    links:
+        - https://tidalcycles.org/index.php/anticipateIn
+clutch:
+    cmd: clutch Time -> [Pattern a] -> Pattern a
+    params:
+    help: |
+        Degrades the current pattern while undegrading the next.
+    links:
+        - https://tidalcycles.org/index.php/clutch
+clutchIn:
+    cmd: clutchIn Time -> Time -> [Pattern a] -> Pattern a
+    params:
+interpolate:
+    cmd: interpolate Time -> [ControlPattern] -> ControlPattern
+    params:
+interpolateIn:
+    cmd: interpolateIn Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+jump:
+    cmd: jump Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Jumps directly into the given pattern, this is essentially the ''no_transition''-transition.
+    links:
+        - https://tidalcycles.org/index.php/jump
+jumpIn:
+    cmd: jumpIn Int -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        `jumpIn'`
+        Unlike jumpIn the variant jumpIn' will only transition at cycle boundary (e.g. when the cycle count is an integer).
+    links:
+        - https://tidalcycles.org/index.php/jumpIn
+jumpMod:
+    cmd: jumpMod Int -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Sharp jump transition at next cycle boundary where cycle mod n == 0.
+    links:
+        - https://tidalcycles.org/index.php/jumpMod
+histpan:
+    cmd: histpan Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Pans the last n versions of the pattern across the field.
+    links:
+        - https://tidalcycles.org/index.php/histpan
+wait:
+    cmd: wait Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Just stop for a bit before playing new pattern.
+    links:
+        - https://tidalcycles.org/index.php/wait
+waitT:
+    cmd: waitT (Time -> [ControlPattern] -> ControlPattern) -> Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Just as wait, waitT stops for a bit and then applies the given transition to the playing pattern.
+    links:
+        - https://tidalcycles.org/index.php/waitT
+wash:
+    cmd: wash (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Time -> Time -> Time -> Time -> [Pattern a] -> Pattern a
+    params:
+    help: |
+        Washes away the current pattern after a certain delay by applying a function to it over time, then switching over to the next pattern to which another function is applied.
+    links:
+        - https://tidalcycles.org/index.php/wash
+washIn:
+    cmd: washIn (Pattern a -> Pattern a) -> Time -> Time -> [Pattern a] -> Pattern a
+    params:
+xfade:
+    cmd: xfade Time -> [ControlPattern] -> ControlPattern
+    params:
+xfadeIn:
+    cmd: xfadeIn Time -> Time -> [ControlPattern] -> ControlPattern
+    params:
+    help: |
+        Applies a crossfade, and fades one pattern out while fading a new pattern in.
+    links:
+        - https://tidalcycles.org/index.php/xfadeIn

--- a/commands.yaml
+++ b/commands.yaml
@@ -1,0 +1,17 @@
+slow:
+  cmd: slow times pattern
+  params:
+    times: The amount to slow down the patern by. Can be a pattern itself
+    pattern: The pattern to slow down
+  returns:
+    A slowed down version of the pattern
+  links:
+    - url: https://tidalcycles.org/index.php/slow
+      title: Tidal Documentation
+  examples:
+    - 'd1 $ slow 4 $ s "bd!8"'
+    - 'd1 $ s "bd!8" # speed (slow 2 $ range 0.95 1.05 square)'
+fast:
+distretise:
+silence:
+hurry:

--- a/commands.yaml
+++ b/commands.yaml
@@ -1,10 +1,12 @@
 slow:
   cmd: slow times pattern
+  help:
+    Slow down a pattern. This effectively changes the number of cycles it takes
+    for the pattern to repeat.
   params:
-    times: The amount to slow down the patern by. Can be a pattern itself
+    times: The amount to slow down the pattern by. Can be a pattern itself
     pattern: The pattern to slow down
-  returns:
-    A slowed down version of the pattern
+  returns: A slowed down version of the pattern
   links:
     - url: https://tidalcycles.org/index.php/slow
       title: Tidal Documentation
@@ -12,6 +14,34 @@ slow:
     - 'd1 $ slow 4 $ s "bd!8"'
     - 'd1 $ s "bd!8" # speed (slow 2 $ range 0.95 1.05 square)'
 fast:
-distretise:
-silence:
-hurry:
+  cmd: fast times pattern
+  help:
+    Speed up a pattern. This effectively changes the number of cycles it takes
+    for the pattern to repeat.
+  params:
+    times: The amount to speed up the pattern by. Can be a pattern itself
+    pattern: The pattern to speed up
+  returns:
+    A sped up version of the pattern
+  links:
+    - url: https://tidalcycles.org/index.php/fast
+      title: Tidal Documentation
+  examples:
+    - 'd1 $ fast 4 $ s "bd!2"'
+    - 'd1 $ s "bd!8" # speed (fast 2 $ range 0.95 1.05 square)'
+stut:
+  cmd: stut repeat time decay
+  help:
+    Similar to a delay, this causes `repeat` versions of the pattern to play
+    with an offset of `time` each. Every time the pattern is repeated, the gain
+    is multiplied with the `decay` values.
+  params:
+    repeat: The number of times to repeat the pattern
+    time: The delay between the repeated patterns
+    decay:
+      The amount to multiply the gain by on each repeat. Values `< 1` will
+      make the repeats more silent each time, values `> 1` will make their
+      volume increase.
+  examples:
+    - 'd1 $ stut 3 (1/3) 0.8 $ s "sd!4"'
+    - 'd1 $ every 2 (stut 3 (1/8) 1.1) $ s "sd!4"'

--- a/commands.yaml
+++ b/commands.yaml
@@ -45,3 +45,17 @@ stut:
   examples:
     - 'd1 $ stut 3 (1/3) 0.8 $ s "sd!4"'
     - 'd1 $ every 2 (stut 3 (1/8) 1.1) $ s "sd!4"'
+setcps:
+  cmd: setcps numcycles
+  help: Set the cycles per second that Tidal should evaluate.
+  params:
+    numcycles: The number of cycles per second. One cycle is usually interpreted as one bar.
+  examples:
+    - |+
+      setcps (120/60/4)
+      d1 $ s "bd!4"
+    - |+
+      setcps (165/60/4)
+      d1 $ s "bd!4"
+  links:
+    - https://tidalcycles.org/index.php/Tutorial

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
             "integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
             "dev": true
         },
+        "@types/js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==",
+            "dev": true
+        },
         "@types/mocha": {
             "version": "5.2.5",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -74,6 +80,14 @@
             "dev": true,
             "requires": {
                 "buffer-equal": "^1.0.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "requires": {
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -441,6 +455,11 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "event-stream": {
             "version": "3.3.4",
@@ -1350,6 +1369,15 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2083,6 +2111,11 @@
                     }
                 }
             }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
             "version": "1.15.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "activationEvents": [
         "onCommand:tidal.eval",
         "onCommand:tidal.evalMulti",
-        "onCommand:tidal.hush"
+        "onCommand:tidal.hush",
+        "onLanguage:haskell"
     ],
     "main": "./out/src/main",
     "contributes": {
@@ -114,6 +115,7 @@
     },
     "devDependencies": {
         "@types/chai": "^4.1.6",
+        "@types/js-yaml": "^3.12.1",
         "@types/mocha": "^5.2.5",
         "@types/node": "^7.0.0",
         "@types/split2": "^2.1.6",
@@ -124,6 +126,7 @@
         "vscode": "^1.1.24"
     },
     "dependencies": {
+        "js-yaml": "^3.13.1",
         "split2": "^3.0.0"
     }
 }

--- a/src/codehelp.ts
+++ b/src/codehelp.ts
@@ -125,7 +125,12 @@ class TidalCommandDescription {
                 + this.examples.map(x => x.value).reduce((x,y) => x+"    \r\n"+y,"")
             )
             .appendMarkdown(this.links.length === 0 ? "" :
-                hline + this.links.map(lnk => `${lnk.title.value}: <${lnk.url}>`).reduce((x,y) => x+"    \r\n"+y,"")
+                hline + this.links
+                    .map(lnk => 
+                        (lnk.title.value.trim() === "" ? "" : `${lnk.title.value}: `)
+                        + `<${lnk.url}>`
+                    )
+                    .reduce((x,y) => x+"    \r\n"+y,"")
             )
             ;
     }
@@ -141,7 +146,9 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
         yamlCommandDefinitions.forEach(({source, ydef}) => {
             try {
                 this.parseYamlDefinitions(ydef)
-                    .forEach(cmd => this.commandDescriptions[cmd.command] = cmd);
+                    .forEach(cmd => {
+                        this.commandDescriptions[cmd.command] = cmd
+                    });
             }
             catch(error){
                 window.showErrorMessage(`Error loading Tidal command descriptions from ${source}: `+error);
@@ -183,12 +190,10 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
 
                             Object.entries(value).map(([parmName, parmprops, ..._]) => {
                                 if(typeof parmName === 'string'){
-                                    if(typeof parmprops === 'string'){
-                                        return new TidalParameterDescription(parmName, new MarkdownString(parmprops));
+                                    if(typeof parmprops !== 'string'){
+                                        parmprops = ""+parmprops;
                                     }
-                                    else {
-                                        throw new Error("Invalid parameter value type "+(typeof parmName));
-                                    }
+                                    return new TidalParameterDescription(parmName, new MarkdownString(parmprops));
                                 }
                                 else {
                                     throw new Error("Invalid parameter key type "+(typeof parmName));

--- a/src/codehelp.ts
+++ b/src/codehelp.ts
@@ -1,0 +1,319 @@
+import { Hover, HoverProvider, Position, TextDocument, CancellationToken, MarkdownString, Range, CompletionItemProvider, CompletionContext, ProviderResult, CompletionItem, CompletionList, Uri, window } from 'vscode'
+
+enum TidalTypeDescription {
+    UNKNOWN
+    , ANY
+    , RATIONAL_PATTERN
+    , CONTROL_PATTERN
+    , TIME_PATTERN
+}
+
+class TidalParameterDescription {
+    constructor(
+        public readonly name:string
+        , public readonly help:MarkdownString
+        , public readonly editable?:boolean
+        , public readonly type?:TidalTypeDescription
+    ){}
+}
+
+class TidalCommandDescription {
+    public readonly formattedCommand:MarkdownString;
+    public readonly parameters:TidalParameterDescription[] | undefined;
+    public readonly returns:{help:MarkdownString,type:TidalTypeDescription | undefined} | undefined;
+    public readonly help:MarkdownString |  undefined;
+    public readonly examples:MarkdownString[];
+    public readonly links:({url:string, title:MarkdownString})[];
+
+    constructor(
+        public readonly command:string
+        , formattedCommand?:string | MarkdownString
+        , parameters?:TidalParameterDescription[]
+        , returns?:{help:MarkdownString | string, type:TidalTypeDescription | undefined}
+        , help?:MarkdownString | string
+        , links:({url:string, title:string | MarkdownString})[] = []
+        , examples:string | string[] | MarkdownString | MarkdownString[] = []
+    ){
+        if(typeof parameters === 'undefined'){
+            this.parameters = [];
+            if(typeof formattedCommand === 'undefined'){
+                this.formattedCommand = new MarkdownString("`"+command+" ?`");
+            }
+            else {
+                this.formattedCommand = typeof formattedCommand === 'string' ? new MarkdownString(formattedCommand) : formattedCommand;
+            }
+        }
+        else {
+            this.parameters = parameters.map(parm => {
+                return {
+                    ...parm
+                    , editable: typeof parm.editable === 'undefined' ? false : parm.editable
+                    , help:(typeof parm.help === 'string' ? new MarkdownString(parm.help) : parm.help)
+                }}
+            );
+            if(typeof formattedCommand === 'undefined'){
+                this.formattedCommand = new MarkdownString("`"+command+" "+this.parameters.map(x => x.name).reduce((x,y) => x+" "+y)+"`");
+            }
+            else {
+                this.formattedCommand = typeof formattedCommand === 'string' ? new MarkdownString(formattedCommand) : formattedCommand;
+            }
+        }
+        this.parameters.forEach(p => p.help.isTrusted = true);
+        this.formattedCommand.isTrusted = true;
+
+        if(typeof returns === 'undefined'){
+            this.returns = undefined;
+        }
+        else {
+            this.returns = {...returns, help:typeof returns.help === 'string' ? new MarkdownString(returns.help) : returns.help};
+            this.returns.help.isTrusted = true;
+        }
+        
+        if(typeof help === 'undefined'){
+            this.help = undefined;
+        }
+        else {
+            this.help = typeof help === 'string' ? new MarkdownString(help) : help;
+            this.help.isTrusted = true;
+        }
+
+        this.links = links.map(link => ({...link, title: typeof link.title === 'string' ?  new MarkdownString(link.title) : link.title}));
+        
+        if(typeof examples === 'string'){
+            this.examples = [new MarkdownString(examples)];
+        }
+        else if(Array.isArray(examples)){
+            this.examples = (examples as (string | MarkdownString)[]).map(x => {
+                if(typeof x === 'string'){
+                    x = new MarkdownString(
+                        "`"+x+"` "
+                        + "[Run]("+Uri.parse("command:tidal.eval?"+encodeURIComponent(JSON.stringify({"command":x})))+")"
+                    )
+                }
+                return x;
+            });
+        }
+        else {
+            this.examples = [examples];
+        }
+        this.examples.forEach(x => {x.isTrusted = true});
+    }
+
+    public format(): MarkdownString {
+        const hline = "\r\n- - -\r\n\r\n";
+        const ms = new MarkdownString()
+        ms.isTrusted = true;
+
+        return ms
+            .appendMarkdown(this.formattedCommand.value)
+            .appendMarkdown(typeof this.help === 'undefined' ? "" : hline + this.help.value)
+            .appendMarkdown(typeof this.parameters === 'undefined' || this.parameters.length === 0 ? "" :
+                hline + this.parameters
+                    .map(x => 
+                    `\`${x.name}\` `
+                    + (typeof x.type !== 'undefined' ? `\`${TidalTypeDescription[x.type]}\`` : "")
+                    + ` ${x.help.value}`)
+                    .reduce((x,y) => x+"    \r\n"+y,"")
+            )
+            .appendMarkdown(typeof this.returns === 'undefined' ? "" :
+                "\r\n\r\n" + "Returns: "
+                + (typeof this.returns.type === 'undefined' ? "" : `\`${TidalTypeDescription[this.returns.type]}\``)
+                + this.returns.help
+            )
+            .appendMarkdown(this.examples.length === 0 ? "" :
+                hline + "Examples:\r\n\r\n"
+                + this.examples.map(x => x.value).reduce((x,y) => x+"    \r\n"+y,"")
+            )
+            .appendMarkdown(this.links.length === 0 ? "" :
+                hline + this.links.map(lnk => `${lnk.title.value}: <${lnk.url}>`).reduce((x,y) => x+"    \r\n"+y,"")
+            )
+            ;
+    }
+
+}
+
+export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemProvider {
+    public readonly commandDescriptions: ({[word:string]:TidalCommandDescription}) = {};
+
+    constructor(
+        yamlCommandDefinitions:({source: string, ydef:object})[]
+    ){
+        yamlCommandDefinitions.forEach(({source, ydef}) => {
+            try {
+                this.parseYamlDefinitions(ydef)
+                    .forEach(cmd => this.commandDescriptions[cmd.command] = cmd);
+            }
+            catch(error){
+                window.showErrorMessage(`Error loading Tidal command descriptions from ${source}: `+error);
+            }
+        });
+    }
+
+    private parseYamlDefinitions(ydef:object): TidalCommandDescription[] {
+        return Object.entries(ydef).map(([command, v, ..._]) => {
+            if(typeof command !== 'string'){
+                throw new Error("Invalid command key type "+(typeof command));
+            }
+
+            let parameters:TidalParameterDescription[] | undefined = undefined;
+            let examples:string[] | undefined = undefined;
+            let links:({url:string, title:string})[] | undefined = undefined;
+            let formattedCommand:string | undefined = undefined;
+            let help:string | undefined = undefined;
+            let returns:{help:MarkdownString | string, type:TidalTypeDescription | undefined} | undefined = undefined;
+
+            if(typeof v == 'object'){
+                Object.entries(v === null ? {} : v).map(([property, value, ..._]) => {
+                    if(typeof property !== 'string'){
+                        throw new Error("Invalid property key type "+(typeof property));
+                    }
+                    if(property === 'cmd' || property === 'formattedCommand'){
+                        if(typeof value === 'string'){
+                            formattedCommand = value;
+                        }
+                    }
+                    else if(property === 'help' || property === 'doc'){
+                        if(typeof value === 'string'){
+                            help = value;
+                        }
+                    }
+                    else if(property === 'parm' || property === 'param' || property === 'params' || property === 'parameters'){
+                        if(typeof value === 'object' && value !== null){
+                            parameters = [];
+
+                            Object.entries(value).map(([parmName, parmprops, ..._]) => {
+                                if(typeof parmName === 'string'){
+                                    if(typeof parmprops === 'string'){
+                                        return new TidalParameterDescription(parmName, new MarkdownString(parmprops));
+                                    }
+                                    else {
+                                        throw new Error("Invalid parameter value type "+(typeof parmName));
+                                    }
+                                }
+                                else {
+                                    throw new Error("Invalid parameter key type "+(typeof parmName));
+                                }
+                            })
+                            .filter(x => typeof x !== 'undefined')
+                            .forEach(x => {
+                                (parameters as TidalParameterDescription[]).push(x);
+                            });
+                        }
+                    }
+                    else if(property === 'example' || property === 'examples'){
+                        if(typeof value === 'string'){
+                            value = [value];
+                        }
+                        
+                        if(Array.isArray(value)) {
+                            examples = value.filter(x => typeof x === 'string');
+                        }
+                    }
+                    else if(property === 'link' || property === 'links'){
+                        if(!Array.isArray(value)){
+                            if(typeof value === 'string' ||  typeof value === 'object'){
+                                value = [value];
+                            }
+                            else {
+                                throw Error("Unknown link type "+(typeof value));
+                            }
+                        }
+                        
+                        links = (value as any[]).map(x => {
+                            if(typeof x === 'string'){
+                                return {url:x, title:""};
+                            }
+                            if(typeof x === 'object'){
+                                return {url:x.url, title: x.title};
+                            }
+                            throw new Error("Unknown link type "+(typeof x));
+                        })
+                        .filter(x => typeof x.url !== 'undefined')
+                        .map(x => ({...x, title: typeof x.title === 'undefined' ? "" : x.title}));
+                        
+                    }
+                });
+            }
+            else if(typeof v === 'string'){
+                command = v;
+            }
+            else {
+                throw new Error("Invalid command description value type "+(typeof v));
+            }
+
+            return new TidalCommandDescription(command, formattedCommand, parameters, returns, help, links, examples);
+        });
+    }
+
+    private getWordAtCursor(document:TextDocument, position:Position): ({word:string |  undefined, range:Range | undefined}){
+        const line = document.lineAt(position.line).text.replace(/--.*$/,'').replace(/\s+$/,'');
+        if(position.character > line.length){
+            return {word:undefined, range:undefined};
+        }
+        let startChar = position.character;
+        for(let i=startChar-1;i>=0;i--){
+            startChar = i;
+            const m = line.charAt(i).match(/^[0-9a-z_]$/i)
+            if(m === null || m.length === 0){
+                startChar = i+1;
+                break;
+            }
+        }
+        let endChar = position.character;
+        for(let i=endChar;i<=line.length;i++){
+            endChar = i;
+            if(i < line.length){
+                const m = line.charAt(i).match(/^[0-9a-z_]$/i)
+                if(m === null || m.length === 0){
+                    break;
+                }
+            }
+        }
+        const htext = line.substr(startChar, endChar-startChar);
+        return {word:htext, range:new Range(position.line, startChar, position.line, endChar)};
+    }
+
+    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionItem[] | CompletionList> {
+        const {word, range} = this.getWordAtCursor(document, position);
+        if(typeof word === 'undefined' || typeof range === 'undefined'){
+            return undefined;
+        }
+        const matches = Object.keys(this.commandDescriptions)
+            .filter(k => k.startsWith(word))
+            .map(k => ({'key':k, 'cdesc':this.commandDescriptions[k]}))
+            .map(({key, cdesc}) => {
+                const item = new CompletionItem(key);
+
+                if(typeof cdesc !== 'undefined'){
+                    item.documentation = cdesc.format();
+                }
+                item.range = range;
+        
+                if(typeof cdesc.parameters === 'undefined'){
+                    item.detail = "Tidal code"
+                }
+                else {
+                    item.insertText = cdesc.command + cdesc.parameters.filter(x => x.editable).map(x => x.name).reduce((x,y)=>x+" "+y,"");
+                }
+
+                return item;
+            })
+        ;
+        return matches;
+    }
+
+    public provideHover(document:TextDocument, position:Position, token:CancellationToken): Hover | undefined {
+        const {word, range} = this.getWordAtCursor(document, position);
+        if(typeof word === 'undefined' || typeof range === 'undefined'){
+            return undefined;
+        }
+        let hoverText = this.commandDescriptions[word];
+        if(typeof hoverText === 'undefined'){
+            return undefined;
+        }
+
+        return new Hover(hoverText.format(), range);
+    }
+
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export function activate(context: ExtensionContext) {
     const history = new History(logger, config);
 
     const hoveAndMarkdownPrivder = new TidalLanguageHelpProvider(
-        ["commands.yaml"].map(x => ([x, path.join(context.extensionPath, x)]))
+        ["commands-generated.yaml","commands.yaml"].map(x => ([x, path.join(context.extensionPath, x)]))
         .map(([source, defPath, ..._]) => {
             const ydef = yaml.load(readFileSync(defPath).toString());
             return {source: source, ydef};

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { TidalLanguageHelpProvider } from './codehelp';
 import * as path from 'path';
 import { TidalExpression } from './editor';
 import * as yaml from 'js-yaml';
-import { readFileSync } from 'fs'
+import { readFileSync } from 'fs';
 
 export function activate(context: ExtensionContext) {
     const config = new Config();

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -42,6 +42,14 @@ export class Repl implements IRepl {
 
         const block = new TidalEditor(this.textEditor).getTidalExpressionUnderCursor(isMultiline);
         
+        this.evaluateExpression(block, isMultiline);
+    }
+
+    public async evaluateExpression(block:TidalExpression | null,isMultiline: boolean) {
+        if (!this.editingTidalFile()) { 
+            return; 
+        }
+        
         if (block) {
             await this.tidal.sendTidalExpression(block.expression);
             this.feedback(block.range);

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -1,0 +1,68 @@
+import { assert } from 'chai';
+
+import * as yaml from 'js-yaml'
+import { TidalLanguageHelpProvider } from '../src/codehelp';
+import { Position, CancellationTokenSource, MarkdownString } from 'vscode';
+import { createMockDocument } from './mock';
+
+suite("Code helper", () => {
+    test("yaml", () => {
+        const testData = yaml.load(`
+foo:
+    cmd: bar
+    links:
+        - link1
+        - url: link2
+        - url: link3
+          title: title3
+`);
+
+        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}]);
+
+        assert.exists(provider.commandDescriptions);
+        assert.isObject(provider.commandDescriptions);
+        assert.hasAllKeys(provider.commandDescriptions, ["foo"]);
+        assert.exists(provider.commandDescriptions["foo"].command);
+        assert.exists(provider.commandDescriptions["foo"].formattedCommand);
+        assert.hasAllKeys(provider.commandDescriptions["foo"].formattedCommand, ["value","isTrusted"]);
+        assert.equal(provider.commandDescriptions["foo"].formattedCommand.value, "bar");
+        assert.isTrue(provider.commandDescriptions["foo"].formattedCommand.isTrusted);
+
+    })
+    test("hover", () => {
+        const testData = yaml.load(`
+foo:
+    cmd: bar
+    links:
+        - link1
+        - url: link2
+        - url: link3
+          title: title3
+`);
+
+        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}]);
+
+        const ts = new CancellationTokenSource();
+
+        let h = provider.provideHover(createMockDocument(["","bar foo baz",""]).object, new Position(1, 5), ts.token);
+
+        assert.exists(h);
+        if(typeof h !== 'undefined'){
+            assert.exists(h.contents);
+            assert.isTrue(h.contents.length > 0);
+            let md = h.contents[0] as MarkdownString;
+            ["bar","link1","link2","link3","title3"].forEach(x =>{
+                assert.isTrue(md.value.indexOf(x) >= 0, `String ${x} missing from hover contents:\n--------------\n${md.value}\n--------------\n`);
+            });
+            assert.exists(h.range);
+            if(typeof h.range !== 'undefined'){
+                assert.equal(h.range.start.line, 1);
+                assert.equal(h.range.start.character, 4);
+                assert.equal(h.range.end.line, 1);
+                assert.equal(h.range.end.character, 7);
+            }
+        }
+
+    })
+})
+

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -77,7 +77,7 @@ foo:
         const ext = vscode.extensions.getExtension("tidalcycles.vscode-tidalcycles");
         assert.exists(ext, "The tidal extension does not exist.");
         if(typeof ext !== 'undefined' && ext !== null){
-            const yf = ["commands.yaml"].map(x => ([x, path.join(ext.extensionPath,x)]))
+            const yf = ["commands-generated.yaml", "commands.yaml"].map(x => ([x, path.join(ext.extensionPath,x)]))
             .map(([source, defPath, ..._]) => {
                 const ydef = yaml.load(readFileSync(defPath).toString());
                 return {source: source, ydef};
@@ -85,7 +85,9 @@ foo:
 
             const provider = new TidalLanguageHelpProvider(yf);
 
-            assert.hasAllKeys(provider.commandDescriptions, ["stut","slow"]);
+            ["stut","slow"].forEach(x => {
+                assert.hasAnyKeys(provider.commandDescriptions, [x], "Expected command descirption for "+x+" to be present");
+            });
         }
     });
 })

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -28,7 +28,7 @@ foo:
         assert.exists(provider.commandDescriptions["foo"].command);
         assert.exists(provider.commandDescriptions["foo"].formattedCommand);
         assert.hasAllKeys(provider.commandDescriptions["foo"].formattedCommand, ["value","isTrusted"]);
-        assert.equal(provider.commandDescriptions["foo"].formattedCommand.value, "bar");
+        assert.equal(provider.commandDescriptions["foo"].formattedCommand.value, "    bar");
         assert.isTrue(provider.commandDescriptions["foo"].formattedCommand.isTrusted);
 
     });

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import * as yaml from 'js-yaml'
+import * as yaml from 'js-yaml';
 import { TidalLanguageHelpProvider } from '../src/codehelp';
 import { Position, CancellationTokenSource, MarkdownString } from 'vscode';
 import { createMockDocument } from './mock';
@@ -31,7 +31,8 @@ foo:
         assert.equal(provider.commandDescriptions["foo"].formattedCommand.value, "bar");
         assert.isTrue(provider.commandDescriptions["foo"].formattedCommand.isTrusted);
 
-    })
+    });
+
     test("hover", () => {
         const testData = yaml.load(`
 foo:
@@ -55,7 +56,10 @@ foo:
             assert.isTrue(h.contents.length > 0);
             let md = h.contents[0] as MarkdownString;
             ["bar","link1","link2","link3","title3"].forEach(x =>{
-                assert.isTrue(md.value.indexOf(x) >= 0, `String ${x} missing from hover contents:\n--------------\n${md.value}\n--------------\n`);
+                assert.isTrue(
+                    md.value.indexOf(x) >= 0
+                    , `String ${x} missing from hover contents:\n--------------\n${md.value}\n--------------\n`
+                );
             });
             assert.exists(h.range);
             if(typeof h.range !== 'undefined'){
@@ -81,7 +85,7 @@ foo:
             .map(([source, defPath, ..._]) => {
                 const ydef = yaml.load(readFileSync(defPath).toString());
                 return {source: source, ydef};
-            })
+            });
 
             const provider = new TidalLanguageHelpProvider(yf);
 
@@ -90,4 +94,4 @@ foo:
             });
         }
     });
-})
+});

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -4,6 +4,9 @@ import * as yaml from 'js-yaml'
 import { TidalLanguageHelpProvider } from '../src/codehelp';
 import { Position, CancellationTokenSource, MarkdownString } from 'vscode';
 import { createMockDocument } from './mock';
+import * as path from 'path';
+import { readFileSync } from 'fs';
+import * as vscode from 'vscode';
 
 suite("Code helper", () => {
     test("yaml", () => {
@@ -63,6 +66,26 @@ foo:
             }
         }
 
-    })
-})
+    });
 
+    test("commands.yaml", (...args) =>{
+        /*
+        try loading the commands from the provided commands.yaml file to make
+        sure it's not causing any errors and that (at least some) values are
+        present.
+        */
+        const ext = vscode.extensions.getExtension("tidalcycles.vscode-tidalcycles");
+        assert.exists(ext, "The tidal extension does not exist.");
+        if(typeof ext !== 'undefined' && ext !== null){
+            const yf = ["commands.yaml"].map(x => ([x, path.join(ext.extensionPath,x)]))
+            .map(([source, defPath, ..._]) => {
+                const ydef = yaml.load(readFileSync(defPath).toString());
+                return {source: source, ydef};
+            })
+
+            const provider = new TidalLanguageHelpProvider(yf);
+
+            assert.hasAllKeys(provider.commandDescriptions, ["stut","slow"]);
+        }
+    });
+})

--- a/tools/parse-doc.js
+++ b/tools/parse-doc.js
@@ -14,14 +14,14 @@ Instructions:
 
 */
 
-const baseUrl = 'https://tidalcycles.org/index.php/'
+const baseUrl = 'https://tidalcycles.org/index.php/';
 
 process.argv.slice(2).forEach(inFile => {
     const fs = require('fs')
     const lines = fs.readFileSync(inFile).toString().split(/(\r?\n)+/);
     const context = {commands:[]};
     
-    console.log(`## ${inFile}`)
+    console.log(`## ${inFile}`);
 
     let patterns = [
         [RegExp(/^\s*[|]\s*[\[]{2,2}(\w+)[\]]{2,2}\s*$/), m => {
@@ -34,7 +34,7 @@ process.argv.slice(2).forEach(inFile => {
                 cmd['args'] = m[1];
                 context.commands.push(cmd);
             }
-            return(m[1])
+            return(m[1]);
         }]
         , [RegExp(/^\s*[|]\s*(.+?)\s*$/i), m => {
             const cmd = context.commands.pop();
@@ -45,7 +45,7 @@ process.argv.slice(2).forEach(inFile => {
                 }
                 context.commands.push(cmd);
             }
-            return(m[1])
+            return(m[1]);
         }]
     ];
 
@@ -100,7 +100,7 @@ process.argv.slice(2).forEach(inFile => {
                 x = x.replace(/<code>\s*(.*?)\s*<\/code>/ig,"`$1`")
                 x = x.replace(/\[{2,2}(.*?)\]{2,2}/ig,"`$1`")
                 ydef = `${ydef}
-        ${x}`
+        ${x}`;
             });
         }
 
@@ -108,7 +108,7 @@ process.argv.slice(2).forEach(inFile => {
         if(typeof cmd.help !== 'undefined' && cmd.help.length > 0){
             ydef = `${ydef}
     links:
-        - ${baseUrl}${cmd.name}`
+        - ${baseUrl}${cmd.name}`;
         }
 
         console.log(ydef);

--- a/tools/parse-doc.js
+++ b/tools/parse-doc.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/*
+
+Instructions:
+
+ * Download wiki text (not HTML source) from the following URLs:
+    * https://tidalcycles.org/index.php/All_the_functions
+    * https://tidalcycles.org/index.php/List_of_Transitions
+    * https://tidalcycles.org/index.php/Control_Functions
+ * Save wiki text to file
+ * Call this script with the file name on the command line
+    * Note that order matters, so it's recommended to have first all functions, then transitionas and then control functions as input
+ * Redirect output as desired
+
+*/
+
+const baseUrl = 'https://tidalcycles.org/index.php/'
+
+process.argv.slice(2).forEach(inFile => {
+    const fs = require('fs')
+    const lines = fs.readFileSync(inFile).toString().split(/(\r?\n)+/);
+    const context = {commands:[]};
+    
+    console.log(`## ${inFile}`)
+
+    let patterns = [
+        [RegExp(/^\s*[|]\s*[\[]{2,2}(\w+)[\]]{2,2}\s*$/), m => {
+            context.commands.push({name:m[1],help:[]});
+            return m[1];
+        }]
+        , [RegExp(/^\s*[|]\s*<code>\s*(.+?)\s*<\/code>\s*$/i), m => {
+            const cmd = context.commands.pop();
+            if(typeof cmd !== 'undefined' && cmd !== null){
+                cmd['args'] = m[1];
+                context.commands.push(cmd);
+            }
+            return(m[1])
+        }]
+        , [RegExp(/^\s*[|]\s*(.+?)\s*$/i), m => {
+            const cmd = context.commands.pop();
+            if(typeof cmd !== 'undefined' && cmd !== null){
+                const val = m[1].trim();
+                if(val.length !== 0 && val.match(/\w+/)){
+                    cmd.help.push(m[1]);
+                }
+                context.commands.push(cmd);
+            }
+            return(m[1])
+        }]
+    ];
+
+    for(let i=0;i<lines.length;i++){
+        for(let j=0;j<patterns.length;j++){
+            const m = lines[i].match(patterns[j][0]);
+            if(typeof m !== 'undefined' && m !== null){
+                patterns[j][1](m);
+                break;
+            }
+        }
+    }
+
+    context.commands.forEach(cmd => {
+        let ydef = `${cmd.name}:`;
+
+        if(typeof cmd.args !== 'undefined' && cmd.args !== null){
+            ydef = `${ydef}
+    cmd: ${cmd.name} ${cmd.args}
+    params:`;
+            let args = cmd.args;
+            let returns = undefined;
+            if(args.indexOf("->") < 0){
+                args = args.split(/\W+/);
+            }
+            else {
+                args = args.split(/\W*->\W*/);
+                returns = args.pop();
+            }
+            /*
+            args.map(x => ([
+                x
+                , x.replace(/[^0-9a-z'_.\[\]]/gi,'').replace(/'/g,"\\'")
+                ]))
+                .filter(x => x[1].length > 0)
+                .forEach(([plain, disp]) => {
+                ydef = `${ydef}
+        - '${disp}': ~`;
+                });
+                */
+        }
+        else {
+            ydef = `${ydef}
+    cmd: ${cmd.name}`;
+        }
+
+        if(cmd.help.length > 0){
+            ydef = `${ydef}
+    help: |`;
+            cmd.help.forEach(x => {
+                x = x.replace(/#/g,"\\#")
+                x = x.replace(/<code>\s*(.*?)\s*<\/code>/ig,"`$1`")
+                x = x.replace(/\[{2,2}(.*?)\]{2,2}/ig,"`$1`")
+                ydef = `${ydef}
+        ${x}`
+            });
+        }
+
+        // usually, if there is not even a help one-liner, there's no page either, so no use in linking to it
+        if(typeof cmd.help !== 'undefined' && cmd.help.length > 0){
+            ydef = `${ydef}
+    links:
+        - ${baseUrl}${cmd.name}`
+        }
+
+        console.log(ydef);
+    })
+});


### PR DESCRIPTION
Hey there. Since I'm bad at remembering command and what parameters they take, I've modified the vscode extension to read command descriptions from a Yaml file and use that info to provide hover and command completion support for Tidal commands.

The matching to the commands is purely done on a string basis at the moment, ignoring only commented out areas. This is the most pragmatic way but might lead to some false-positives, e.g. it'll match tidal identifiers also in strings.

One, IMHO, nice feature for beginners is that every command description can also hold some examples, which can be executed right away from the message window, by clicking on `run` next to the example. This sends the command internally the existing `tidal.eval` command, which I enabled to take additional parameters.

As of this commit/pull request the command definitions are ... sparse :) If you're interested in merging this to your master, I'll add some more commands. Maybe there's even a way to generate the info from the Tidal doc itself.

Additional things that might be worth doing, and which I've held off until I get some feedback, are:

 * Make the hover/completion support configurable (enable/disable)
 * Support additional, user defined files to load
 * Support for help on command parameters while typing

Let me know what you think. Cheers, oscons