### PR TITLE
Configuration support for hover and completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Available levels for bothh options are:
 
 **Note**: Not every command is documented yet and the detail level of the
 documentation varies from command to command. The files
-[commands.yaml] and [commands-generated.yaml] contain the currently supported
-commands and their documentation. If you'd like to contribute, please add new
-documentation to [commands.yaml].
+[commands.yaml](commands.yaml) and [commands-generated.yaml](commands-generated.yaml)
+contain the currently available documentation. If you'd like to contribute,
+please add new documentation to [commands.yaml](commands.yaml).
 
 ### Full Config Example
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ Examples:
 "tidalcycles.useBootFileInCurrentDirectory" : true
 ```
 
+### Hover / completion support for Tidal statements
+
+This extension implements some code support features for Tidal specific
+statements, providing code completion and hover information.
+
+You can set the detail level of the provided information through two
+configuration settings, one for the `hover` feature and one for `completion`:
+
+```
+"tidalcycles.codehelp.hover.level": "FULL"
+"tidalcycles.codehelp.completion.level" : "FULL"
+```
+
+Available levels for bothh options are:
+
+ * `OFF`: Disables the feature
+ * `FULL`: Enables all available information 
+ * `NO_LINKS_NO_EXAMPLES`: Only show command format, parameters and return value
+                           information
+ * `MINIMUM`: Only show command format information
+
+**Note**: Not every command is documented yet and the detail level of the
+documentation varies from command to command. The files
+[commands.yaml] and [commands-generated.yaml] contain the currently supported
+commands and their documentation. If you'd like to contribute, please add new
+documentation to [commands.yaml].
+
 ### Full Config Example
 
 ```
@@ -92,7 +119,9 @@ Examples:
     "tidalcycles.showGhciOutput": false,
     "tidalcycles.showOutputInConsoleChannel": true,
     "tidalcycles.useBootFileInCurrentDirectory": false,
-    "tidalcycles.bootTidalPath" : "c:\\path\\to\\file\\boot.tidal"
+    "tidalcycles.bootTidalPath" : "c:\\path\\to\\file\\boot.tidal",
+    "tidalcycles.codehelp.hover.level": "FULL",
+    "tidalcycles.codehelp.completion.level" : "FULL"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SuperCollider orbits 0 through 11, respectively.
 
 This VSCode extension for TidalCycles is inspired by the commands from the popular Atom package:
 
-- `Shift+Enter` to evalulate a single line
+- `Shift+Enter` to evaluate a single line
 - `Ctrl+Enter` to evaluate multiple lines
 - `Ctrl+Alt+H` to hush
 
@@ -93,7 +93,7 @@ configuration settings, one for the `hover` feature and one for `completion`:
 "tidalcycles.codehelp.completion.level" : "FULL"
 ```
 
-Available levels for bothh options are:
+Available levels for both options are:
 
  * `OFF`: Disables the feature
  * `FULL`: Enables all available information 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Available levels for bothh options are:
 
  * `OFF`: Disables the feature
  * `FULL`: Enables all available information 
- * `NO_LINKS_NO_EXAMPLES`: Only show command format, parameters and return value
+ * `NO_EXAMPLES_NO_LINKS`: Only show command format, parameters and return value
                            information
  * `MINIMUM`: Only show command format information
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,28 @@
                     "default": false,
                     "description": "Use the GHCi instance provided by Stack in the current folder. If false, use the system-wide GHCi path."
                 }
+                , "tidalcycles.codehelp.hover.level" :{
+                    "type": "string"
+                    , "default": "Full"
+                    , "enum": [
+                        "Off"
+                        , "Minimum"
+                        , "No examples or links"
+                        , "Full"
+                    ]
+                    , "description": "How much information to show for hovering Tidal code info."
+                }
+                , "tidalcycles.codehelp.completion.level" :{
+                    "type": "string"
+                    , "default": "Full"
+                    , "enum": [
+                        "Off"
+                        , "Minimum"
+                        , "No examples or links"
+                        , "Full"
+                    ]
+                    , "description": "How much information to show for Tidal code completion info."
+                }
             }
         }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { CodeHelpDetailLevel } from './codehelp';
 
 export class Config {
     getConfiguration = vscode.workspace.getConfiguration;
@@ -34,5 +35,33 @@ export class Config {
 
     public useStackGhci(): boolean {
         return this.getConfiguration(this.configSection).get('useStackGhci', false);
+    }
+
+    public getHoverHelpDetailLevel(): CodeHelpDetailLevel {
+        let level = this.getConfiguration(this.configSection)
+            .get("codehelp.hover.level", CodeHelpDetailLevel[CodeHelpDetailLevel.FULL] as string);
+        return this.stringToCodeHelpDetailLevel(level);
+    }
+
+    public getCompletionHelpDetailLevel(): CodeHelpDetailLevel {
+        let level = this.getConfiguration(this.configSection)
+            .get("codehelp.completion.level", CodeHelpDetailLevel[CodeHelpDetailLevel.FULL] as string);
+        return this.stringToCodeHelpDetailLevel(level);
+    }
+
+    public stringToCodeHelpDetailLevel(level:string){
+        level = level.toUpperCase().replace(/\s+/g,'_');
+
+        let enumLevel:CodeHelpDetailLevel | undefined = CodeHelpDetailLevel.FULL;
+        try {
+            enumLevel = CodeHelpDetailLevel[<keyof typeof CodeHelpDetailLevel>level];
+            if(typeof enumLevel === 'undefined'){
+                enumLevel = CodeHelpDetailLevel.FULL;
+            }
+        }
+        catch(error){
+            vscode.window.showErrorMessage("Could not convert "+level+" to CodeHelpDetailLevel: "+error);
+        }
+        return enumLevel;
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export function activate(context: ExtensionContext) {
     
     [languages.registerHoverProvider, languages.registerCompletionItemProvider]
         .forEach((regFunc:((selector:any, provider:any) => void)) => {
-            regFunc({scheme:"*", language: 'haskell',pattern: '**/*.tidal'}, hoveAndMarkdownPrivder);
+            regFunc({scheme:"*", pattern: '**/*.tidal'}, hoveAndMarkdownPrivder);
         });
 
     function getRepl(repls: Map<TextEditor, Repl>, textEditor: TextEditor | undefined): Repl | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,9 @@ export function activate(context: ExtensionContext) {
             const ydef = yaml.load(readFileSync(defPath).toString());
             return {source: source, ydef};
         })
+        , config
     );
+    
     [languages.registerHoverProvider, languages.registerCompletionItemProvider]
         .forEach((regFunc:((selector:any, provider:any) => void)) => {
             regFunc({scheme:"*", language: 'haskell',pattern: '**/*.tidal'}, hoveAndMarkdownPrivder);

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -1,76 +1,219 @@
 import { assert } from 'chai';
 
 import * as yaml from 'js-yaml';
-import { TidalLanguageHelpProvider } from '../src/codehelp';
+import { TidalLanguageHelpProvider, CodeHelpDetailLevel } from '../src/codehelp';
 import { Position, CancellationTokenSource, MarkdownString } from 'vscode';
 import { createMockDocument } from './mock';
 import * as path from 'path';
 import { readFileSync } from 'fs';
 import * as vscode from 'vscode';
 
+import * as TypeMoq from 'typemoq';
+import { Config } from '../src/config';
+
 suite("Code helper", () => {
-    test("yaml", () => {
-        const testData = yaml.load(`
-foo:
-    cmd: bar
+
+    function createMockTestConfig(hoverLevel:string, completionLevel:string): TypeMoq.IMock<Config>{
+        let config = new Config();
+        let mockConfig = TypeMoq.Mock.ofInstance(config, );
+
+        mockConfig
+            .setup(x => x.getHoverHelpDetailLevel())
+            .returns(x => CodeHelpDetailLevel[<keyof typeof CodeHelpDetailLevel>hoverLevel]);
+
+        mockConfig
+            .setup(x => x.getCompletionHelpDetailLevel())
+            .returns(x => CodeHelpDetailLevel[<keyof typeof CodeHelpDetailLevel>completionLevel]);
+
+        return mockConfig;
+    }
+
+    test("config", () => {
+        let config = new Config();
+        ['FULL','MINIMUM','OFF','NO_EXAMPLES_NO_LINKS',"foo"].forEach(x => {    
+            if(x === "foo"){
+                assert.equal(
+                    config.stringToCodeHelpDetailLevel(x)
+                    , CodeHelpDetailLevel['FULL']
+                );
+            }
+            else {
+                assert.equal(
+                    config.stringToCodeHelpDetailLevel(x)
+                    , CodeHelpDetailLevel[<keyof typeof CodeHelpDetailLevel>x]
+                );
+            }
+        });
+    });
+
+    const testData = yaml.load(`
+commandName:
+    cmd: commandLine
+    returns: returnValue
+    params:
+        param: paramValue
     links:
         - link1
         - url: link2
         - url: link3
           title: title3
+    examples:
+        - |+
+            exampleText
 `);
 
-        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}]);
+    test("yaml processing", () => {
+        const config = createMockTestConfig('FULL', 'FULL');
+        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}], config.object);
 
         assert.exists(provider.commandDescriptions);
         assert.isObject(provider.commandDescriptions);
-        assert.hasAllKeys(provider.commandDescriptions, ["foo"]);
-        assert.exists(provider.commandDescriptions["foo"].command);
-        assert.exists(provider.commandDescriptions["foo"].formattedCommand);
-        assert.hasAllKeys(provider.commandDescriptions["foo"].formattedCommand, ["value","isTrusted"]);
-        assert.equal(provider.commandDescriptions["foo"].formattedCommand.value, "    bar");
-        assert.isTrue(provider.commandDescriptions["foo"].formattedCommand.isTrusted);
+        assert.hasAllKeys(provider.commandDescriptions, ["commandName"]);
+        assert.exists(provider.commandDescriptions["commandName"].command);
+        assert.exists(provider.commandDescriptions["commandName"].formattedCommand);
+        assert.hasAllKeys(provider.commandDescriptions["commandName"].formattedCommand, ["value","isTrusted"]);
+        assert.equal(provider.commandDescriptions["commandName"].formattedCommand.value, "    commandLine");
+        assert.isTrue(provider.commandDescriptions["commandName"].formattedCommand.isTrusted);
 
     });
 
-    test("hover", () => {
-        const testData = yaml.load(`
-foo:
-    cmd: bar
-    links:
-        - link1
-        - url: link2
-        - url: link3
-          title: title3
-`);
+    ["hover", "complete"].forEach(helpType => {
+        suite(helpType + " content", () => {
+            [
+                {level: "FULL"
+                    , contains:["    commandLine","param","paramValue"
+                        ,"returnValue","link1","link2","link3","title3","exampleText"]
+                    , notContains:["commandName"]}
+                , {level: "OFF"
+                    , contains:[]
+                    , notContains:["commandName","    commandLine","param","paramValue"
+                        , "returnValue","link1","link2","link3","title3","exampleText"]}
+                , {level: "MINIMUM"
+                    , contains:["    commandLine"]
+                    , notContains:["param","paramValue"
+                        ,"returnValue","link1","link2","link3","title3","exampleText"]}
+                , {level: "NO_EXAMPLES_NO_LINKS"
+                    , contains:["    commandLine","param","paramValue"
+                        ,"returnValue"]
+                    , notContains:["commandName","link1","link2","link3","title3","exampleText"]}
+            ].forEach(({level, contains, notContains}) => {
+                test("Level: "+level, () => {
+                    const config = createMockTestConfig(level, level);
+                    const provider = new TidalLanguageHelpProvider(
+                        [{source:"test1",ydef:testData}]
+                        , config.object
+                    );
+            
+                    const ts = new CancellationTokenSource();
+            
+                    
+                    let h;
+                    if(helpType === 'complete'){
+                        h = provider.provideCompletionItems(
+                            createMockDocument(["","    commandName arg1 arg2",""]).object
+                            , new Position(1, 5)
+                            , ts.token
+                            , TypeMoq.Mock.ofType<vscode.CompletionContext>().object
+                        );
+                        if(level === 'OFF'){
+                            if(typeof h === 'undefined' || h === null) {
+                                assert.notExists(h);
+                            }
+                            else if(Array.isArray(h)){
+                                assert.equal(h.length, 0);
+                            }
+                            else if(typeof h === 'object') {
+                                assert.equal((h as vscode.CompletionList).items.length, 0);
+                            }
+                            h = undefined;
+                        }
+                        else {
+                            assert.exists(h);
+                            if(Array.isArray(h)){
+                                assert.equal(h.length, 1);
+                                h = h[0];
+                            }
+                            else if(typeof h === 'object') {
+                                h = (h as vscode.CompletionList).items;
+                                assert.exists(h);
+                                assert.equal(h.length, 1);
+                                h = h[0];
+                            }
+                            else {
+                                // we should never get here
+                                assert.isTrue(false);
+                                console.log(h);
+                                throw new Error("invalid result type");
+                            }
+                            assert.equal(h.detail, "    commandLine");
+                            assert.exists(h.documentation);
+                            h = h.documentation;
+                            assert.typeOf(h, "object");
+                            assertContents(
+                                helpType
+                                , h as MarkdownString
+                                , contains.filter(x => x !== '    commandLine')
+                                , notContains.reduce((x,y) => {x.push(y); return x;}, ["    commandLine"])
+                            );
+                        }
 
-        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}]);
+                    }
+                    else if(helpType === 'hover') {
+                        h = provider.provideHover(
+                            createMockDocument(["","    commandName arg1 arg2",""]).object
+                            , new Position(1, 5)
+                            , ts.token
+                        );
+                        if(level === 'OFF'){
+                            assert.notExists(h);
+                            h = undefined;
+                        }
+                        else {
+                            assert.exists(h);
+                            if(typeof h !== 'undefined') {
+                                assert.isObject(h);
+                                assert.isArray(h.contents);
+                                assert.isTrue(h.contents.length > 0);
+                                assert.isObject(h.contents[0]);
+                                assertContents(
+                                    helpType
+                                    , h.contents[0] as MarkdownString
+                                    , contains
+                                    , notContains
+                                );
 
-        const ts = new CancellationTokenSource();
-
-        let h = provider.provideHover(createMockDocument(["","bar foo baz",""]).object, new Position(1, 5), ts.token);
-
-        assert.exists(h);
-        if(typeof h !== 'undefined'){
-            assert.exists(h.contents);
-            assert.isTrue(h.contents.length > 0);
-            let md = h.contents[0] as MarkdownString;
-            ["bar","link1","link2","link3","title3"].forEach(x =>{
-                assert.isTrue(
-                    md.value.indexOf(x) >= 0
-                    , `String ${x} missing from hover contents:\n--------------\n${md.value}\n--------------\n`
-                );
+                                assert.exists(h.range);
+                                if(typeof h.range !== 'undefined'){
+                                    assert.equal(h.range.start.line, 1);
+                                    assert.equal(h.range.start.character, 4);
+                                    assert.equal(h.range.end.line, 1);
+                                    assert.equal(h.range.end.character, "commandName".length+h.range.start.character);
+                                }
+                            }
+                        }
+                    }
+                });
             });
-            assert.exists(h.range);
-            if(typeof h.range !== 'undefined'){
-                assert.equal(h.range.start.line, 1);
-                assert.equal(h.range.start.character, 4);
-                assert.equal(h.range.end.line, 1);
-                assert.equal(h.range.end.character, 7);
-            }
-        }
-
+        });
     });
+
+    function assertContents(type:string, s:MarkdownString, contains:string[], notContains:string[]){
+        contains.forEach(x =>{
+            assert.isTrue(
+                s.value.indexOf(x) >= 0
+                , `Expected string ${x} missing from ${type} contents:
+--------------\n${s.value}\n--------------\n`
+            );
+        });
+        notContains.forEach(x =>{
+            assert.isFalse(
+                s.value.indexOf(x) >= 0
+                , `Unexpected string ${x} present in ${type} contents:
+--------------\n${s.value}\n--------------\n`
+            );
+        });
+
+    }
 
     test("commands.yaml", (...args) =>{
         /*
@@ -87,7 +230,9 @@ foo:
                 return {source: source, ydef};
             });
 
-            const provider = new TidalLanguageHelpProvider(yf);
+            const config = createMockTestConfig('FULL', 'FULL');
+        
+            const provider = new TidalLanguageHelpProvider(yf, config.object);
 
             ["stut","slow"].forEach(x => {
                 assert.hasAnyKeys(provider.commandDescriptions, [x], "Expected command descirption for "+x+" to be present");


### PR DESCRIPTION
As promised in the [last pull request](https://github.com/tidalcycles/vscode-tidalcycles/pull/14#issuecomment-524948438) here's the code to make the hover and completion support configurable. There are four levels of detail supported: `OFF`, `MINIMUM`, `NO_EXAMPLES_NO_LINKS`, `FULL`.

Let me know, what you think.