### PR TITLE
Shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,42 @@ This VSCode extension for TidalCycles is inspired by the commands from the popul
 - `Ctrl+Enter` to evaluate multiple lines
 - `Ctrl+Alt+H` to hush
 
+### Customizeable shortcuts
+
+You have 9 customizeable shortcuts for executing commands e.g. through key combinations. By default shortcuts 1 through
+5 and 9 are initially set up to do the following:
+
+1. `silence` the current stream
+2. `mute` the current stream
+3. `unmute` the current stream
+4. `solo` the current stream
+5. `unsolo` the current stream
+9. The more complex example below
+
+The current stream number is determined by determining of theres a `d1`, `d2`, etc at the beginning of the first line.
+The number is then taken as the current stream number.
+
+You can use this number in the commands by putting a `#s#` at the position you want the number to be. Note that it's
+replaced with the number only, no spaces are added. So if you're on stream `4` and you have a shortcut command that's
+defined as `d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#` it'll be translated to `d4 $ ((1/4) ~>) $ s \"bd\" # speed 4`
+before being sent to Tidal.
+
+Note that the extension does not come with default key bindings to not interfere with your set up. In order to execute
+the commands through key combinations you need to wire them up in the `Keyboard Shortcut` preferences.
+
+If the 9 predefined shortcut slots are not enough, you can also define new ones by creating new keyboard mappings.
+Below is an example that needs to go into your `keybindings.json` file.
+
+```
+{
+    "key": "shift+ctrl+1"
+    , "command": "tidal.shortcut"
+    , "args": {
+        "command": "d1 $ stack [ s \"bd!4\", ((1/2) ~>) $ s \"sn!2\" ]"
+    }
+}
+```
+
 ## Syntax Highlighting
 
 In order to get syntax highlighting in `.tidal` files you must do

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This VSCode extension for TidalCycles is inspired by the commands from the popul
 - `Ctrl+Enter` to evaluate multiple lines
 - `Ctrl+Alt+H` to hush
 
-### Customizeable shortcuts
+### Customizable shortcuts
 
-You have 9 customizeable, predefined shortcuts for executing commands e.g. through key combinations. By default
-the shortcuts are initially set up to do the following:
+You have 9 customizable, predefined shortcuts for executing commands e.g. through key combinations. By default
+the shortcuts are initially set up to do the following (you can change them to your liking though):
 
 1. `silence` the current stream
 2. `mute` the current stream
@@ -32,13 +32,13 @@ the shortcuts are initially set up to do the following:
 8. `xfadeIn` `silence` to the current stream over 4 cycles. Effectively this is a fade out
 9. The more complex example below
 
-The current stream number is determined by determining of theres a `d1`, `d2`, etc at the beginning of the first line.
-The number is then taken as the current stream number.
+The current stream number is determined by checking for a `d1`, `d2`, etc. at the beginning of the first line of the
+code block the cursor is currently in. This number is then taken as the current stream number, sans the `d`.
 
-You can use this number in the commands by putting a `#s#` at the position you want the number to be. Note that it's
-replaced with the number only, no spaces are added. So if you're on stream `4` and you have a shortcut command that's
-defined as `d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#` it'll be translated to `d4 $ ((1/4) ~>) $ s \"bd\" # speed 4`
-before being sent to Tidal (see default command 9).
+You can use the stream number in the commands by putting a `#s#` at the position you want the number to be. Note that
+it is replaced by the number only, no spaces are added. So if you're on stream `4` and you have a shortcut command
+that's defined as `d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#` it'll be translated to
+`d4 $ ((1/4) ~>) $ s \"bd\" # speed 4` before being sent to Tidal (see default command 9).
 
 Another useful replacement value is `#c#` which is the remainder of the command after the first `$` or `#`. This makes
 it easy to set up shortcuts for transitions. The following shortcut will cross fade in the block under the cursor over 4
@@ -48,12 +48,14 @@ cycles:
 xfadeIn #s# 4 $ #c#
 ```
 
-Note that the extension does not come with default key bindings to not interfere with your set up. In order to execute
-the commands through key combinations you need to wire them up in the `Keyboard Shortcut` preferences.
+Note that the extension **does not come with default key bindings** as to not interfere with your current key bindings.
+In order to execute the commands through key combinations you need to wire them up in the `Keyboard Shortcut`
+preferences.
 
-If the 9 predefined shortcut slots are not enough, you can also define new ones by creating new keyboard mappings.
+If the 9 predefined shortcut commands are not enough, you can also define new ones by creating new keyboard mappings.
 Defining a shortcut like this also has the added benefit of allowing for multiple, top level commands to be specified in
-the same shortcut. Below is an example that needs to go into your `keybindings.json` file.
+the same shortcut. Below is an example that needs to go into your `keybindings.json` file. Note the `\r\n` added to
+define two top level commands in the same shortcut.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ Note that the extension does not come with default key bindings to not interfere
 the commands through key combinations you need to wire them up in the `Keyboard Shortcut` preferences.
 
 If the 9 predefined shortcut slots are not enough, you can also define new ones by creating new keyboard mappings.
-Below is an example that needs to go into your `keybindings.json` file.
+Defining a shortcut like this also has the added benefit of allowing for multiple, top level commands to be specified in
+the same shortcut. Below is an example that needs to go into your `keybindings.json` file.
 
 ```
 {
     "key": "shift+ctrl+1"
     , "command": "tidal.shortcut"
     , "args": {
-        "command": "d1 $ stack [ s \"bd!4\", ((1/2) ~>) $ s \"sn!2\" ]"
+        "command": "d1 $ stack [ s \"bd!4\", ((1/2) ~>) $ s \"sn!2\" ]\r\nd2 $ s \"hh!8\""
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ This VSCode extension for TidalCycles is inspired by the commands from the popul
 
 ### Customizeable shortcuts
 
-You have 9 customizeable shortcuts for executing commands e.g. through key combinations. By default shortcuts 1 through
-5 and 9 are initially set up to do the following:
+You have 9 customizeable, predefined shortcuts for executing commands e.g. through key combinations. By default
+the shortcuts are initially set up to do the following:
 
 1. `silence` the current stream
 2. `mute` the current stream
 3. `unmute` the current stream
 4. `solo` the current stream
 5. `unsolo` the current stream
+6. `unsolo` and `unmute` streams 1 to 12
+7. `xfadeIn` the block to the current stream over 4 cycles (see below)
+8. `xfadeIn` `silence` to the current stream over 4 cycles. Effectively this is a fade out
 9. The more complex example below
 
 The current stream number is determined by determining of theres a `d1`, `d2`, etc at the beginning of the first line.
@@ -35,7 +38,15 @@ The number is then taken as the current stream number.
 You can use this number in the commands by putting a `#s#` at the position you want the number to be. Note that it's
 replaced with the number only, no spaces are added. So if you're on stream `4` and you have a shortcut command that's
 defined as `d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#` it'll be translated to `d4 $ ((1/4) ~>) $ s \"bd\" # speed 4`
-before being sent to Tidal.
+before being sent to Tidal (see default command 9).
+
+Another useful replacement value is `#c#` which is the remainder of the command after the first `$` or `#`. This makes
+it easy to set up shortcuts for transitions. The following shortcut will cross fade in the block under the cursor over 4
+cycles:
+
+```
+xfadeIn #s# 4 $ #c#
+```
 
 Note that the extension does not come with default key bindings to not interfere with your set up. In order to execute
 the commands through key combinations you need to wire them up in the `Keyboard Shortcut` preferences.

--- a/package.json
+++ b/package.json
@@ -192,17 +192,17 @@
                 },
                 "tidalcycles.shortcuts.no6": {
                     "type": "string",
-                    "default": "",
+                    "default": "mapM unmute [1..12]\r\nmapM unsolo [1..12]",
                     "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #6` extension command is executed."
                 },
                 "tidalcycles.shortcuts.no7": {
                     "type": "string",
-                    "default": "",
+                    "default": "xfadeIn #s# 4 $ #c#",
                     "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #7` extension command is executed."
                 },
                 "tidalcycles.shortcuts.no8": {
                     "type": "string",
-                    "default": "",
+                    "default": "xfadeIn #s# 4 $ silence",
                     "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #8` extension command is executed."
                 },
                 "tidalcycles.shortcuts.no9": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,15 @@
         "onCommand:tidal.eval",
         "onCommand:tidal.evalMulti",
         "onCommand:tidal.hush",
+        "onCommand:tidal.shortcut.no1",
+        "onCommand:tidal.shortcut.no2",
+        "onCommand:tidal.shortcut.no3",
+        "onCommand:tidal.shortcut.no4",
+        "onCommand:tidal.shortcut.no5",
+        "onCommand:tidal.shortcut.no6",
+        "onCommand:tidal.shortcut.no7",
+        "onCommand:tidal.shortcut.no8",
+        "onCommand:tidal.shortcut.no9",
         "onLanguage:haskell"
     ],
     "main": "./out/src/main",
@@ -33,6 +42,59 @@
             {
                 "command": "tidal.hush",
                 "title": "Tidal Hush"
+            },
+            {
+                "command": "tidal.shush",
+                "title": "Tidal Shush"
+            },
+            {
+                "command": "tidal.shortcut",
+                "title": "Tidal Shortcut with arguments"
+            },
+            {
+                "command": "tidal.shortcut.no1",
+                "title": "Tidal Shortcut #1",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no2",
+                "title": "Tidal Shortcut #2",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no3",
+                "title": "Tidal Shortcut #3",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no4",
+                "title": "Tidal Shortcut #4",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no5",
+                "title": "Tidal Shortcut #5",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no6",
+                "title": "Tidal Shortcut #6",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no7",
+                "title": "Tidal Shortcut #7",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no8",
+                "title": "Tidal Shortcut #8",
+                "category": "Tidal Shortcuts"
+            },
+            {
+                "command": "tidal.shortcut.no9",
+                "title": "Tidal Shortcut #9",
+                "category": "Tidal Shortcuts"
             }
         ],
         "keybindings": [
@@ -102,6 +164,51 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Use the GHCi instance provided by Stack in the current folder. If false, use the system-wide GHCi path."
+                },
+                "tidalcycles.shortcuts.no1": {
+                    "type": "string",
+                    "default": "d#s# $ silence",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #1` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no2": {
+                    "type": "string",
+                    "default": "mute #s#",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #2` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no3": {
+                    "type": "string",
+                    "default": "unmute #s#",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #3` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no4": {
+                    "type": "string",
+                    "default": "solo #s#",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #4` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no5": {
+                    "type": "string",
+                    "default": "unsolo #s#",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #5` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no6": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #6` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no7": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #7` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no8": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #8` extension command is executed."
+                },
+                "tidalcycles.shortcuts.no9": {
+                    "type": "string",
+                    "default": "d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#",
+                    "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #9` extension command is executed."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -209,8 +209,13 @@
                     "type": "string",
                     "default": "d#s# $ ((1/#s#) ~>) $ s \"bd\" # speed #s#",
                     "markdownDescription": "The tidal command to execute when the `Tidal Shortcut #9` extension command is executed."
-                }
-                , "tidalcycles.codehelp.hover.level" :{
+                },
+                "tidalcycles.shortcuts.showInConsole": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Show the shortcut commands that are executed in the console. Useful for debugging."
+                },
+                "tidalcycles.codehelp.hover.level" :{
                     "type": "string"
                     , "default": "Full"
                     , "enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,10 @@ export class Config {
         return this.getConfiguration(this.configSection).get(`shortcuts.no${num}`, "");
     }
 
+    public showShortcutCommandInConsole(): boolean {
+        return this.getConfiguration(this.configSection).get('shortcuts.showInConsole', false);
+    }
+
     public getHoverHelpDetailLevel(): CodeHelpDetailLevel {
         let level = this.getConfiguration(this.configSection)
             .get("codehelp.hover.level", CodeHelpDetailLevel[CodeHelpDetailLevel.FULL] as string);

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,4 +35,8 @@ export class Config {
     public useStackGhci(): boolean {
         return this.getConfiguration(this.configSection).get('useStackGhci', false);
     }
+
+    public getShortcutCommand(num: number): string {
+        return this.getConfiguration(this.configSection).get(`shortcuts.no${num}`, "");
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { TextEditor, ExtensionContext, window, commands, languages, Range } from 'vscode';
-import { Repl, splitCommands } from './repl';
+import { DEFAULT_TEMPLATE_MARKER, Repl, splitCommands } from './repl';
 import { Logger } from './logging';
 import { Config } from './config';
 import { Ghci } from './ghci';
@@ -98,7 +98,9 @@ export function activate(context: ExtensionContext) {
         const repl = getRepl(repls, window.activeTextEditor);
         if (repl !== undefined) {
             const expressions = splitCommands(shortcut);
-            expressions.forEach(e => repl.executeTemplate(e.expression));
+            expressions.forEach(e =>
+                repl.executeTemplate(e.expression, DEFAULT_TEMPLATE_MARKER, config.showShortcutCommandInConsole())
+            );
         }
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,17 +89,21 @@ export function activate(context: ExtensionContext) {
         }
     });
 
+    const executeShortcut = (shortcut: string | undefined) => {
+        if(typeof shortcut === 'undefined' || shortcut === null || shortcut.trim() === ''){
+            return;
+        }
+        const repl = getRepl(repls, window.activeTextEditor);
+        if (repl !== undefined) {
+            const expressions = splitCommands(shortcut);
+            expressions.forEach(e => repl.evaluateExpression(e, true));
+        }
+    };
+
     const shortcutCommands = Array(9).fill(1).map((_, i) => {
         i = i + 1;
         return commands.registerCommand(`tidal.shortcut.no${i}`, function() {
-            const shortcut = config.getShortcutCommand(i);
-            if(typeof shortcut === 'undefined' || shortcut === null || shortcut.trim() === ''){
-                return;
-            }
-            const repl = getRepl(repls, window.activeTextEditor);
-            if (repl !== undefined) {
-                repl.executeTemplate(shortcut);
-            }
+            executeShortcut(config.getShortcutCommand(i));
         });
     });
 
@@ -110,14 +114,7 @@ export function activate(context: ExtensionContext) {
             }
             let command = Object.keys(args).filter(x => x === 'command').map(x=>args[x]).pop() as string | undefined;
 
-            if(typeof command === 'undefined'){
-                return undefined;
-            }
-            
-            const repl = getRepl(repls, window.activeTextEditor);
-            if (repl !== undefined) {
-                repl.executeTemplate(command);
-            }
+            executeShortcut(command);
         });
     })());
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ export function activate(context: ExtensionContext) {
         const repl = getRepl(repls, window.activeTextEditor);
         if (repl !== undefined) {
             const expressions = splitCommands(shortcut);
-            expressions.forEach(e => repl.evaluateExpression(e, true));
+            expressions.forEach(e => repl.executeTemplate(e.expression));
         }
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,42 @@ export function activate(context: ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(evalSingleCommand, evalMultiCommand, hushCommand);
+    const shortcutCommands = Array(9).fill(1).map((_, i) => {
+        i = i + 1;
+        return commands.registerCommand(`tidal.shortcut.no${i}`, function() {
+            const shortcut = config.getShortcutCommand(i);
+            if(typeof shortcut === 'undefined' || shortcut === null || shortcut.trim() === ''){
+                return;
+            }
+            const repl = getRepl(repls, window.activeTextEditor);
+            if (repl !== undefined) {
+                repl.executeTemplate(shortcut);
+            }
+        });
+    });
+
+    shortcutCommands.push((() => {
+        return commands.registerCommand('tidal.shortcut', (args?:{[key:string]:any}) => {
+            if(typeof args === 'undefined'){
+                return undefined;
+            }
+            let command = Object.keys(args).filter(x => x === 'command').map(x=>args[x]).pop() as string | undefined;
+
+            if(typeof command === 'undefined'){
+                return undefined;
+            }
+            
+            const repl = getRepl(repls, window.activeTextEditor);
+            if (repl !== undefined) {
+                repl.executeTemplate(command);
+            }
+        });
+    })());
+
+    context.subscriptions.push(
+        evalSingleCommand, evalMultiCommand, hushCommand
+        , ...shortcutCommands.filter(x => typeof x !== 'undefined')
+    );
 }
 
 export function deactivate() { }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -46,7 +46,7 @@ export class Repl implements IRepl {
 
         if(template.search(marker) >= 0){
             if(block === null){
-                vscode.window.showErrorMessage(`    Command template contains merkers but
+                vscode.window.showErrorMessage(`    Command template contains markers but
                                                     there is no valid code block at the
                                                     cursor location: ${template}`
                 );

--- a/src/tidal.ts
+++ b/src/tidal.ts
@@ -7,7 +7,7 @@ import { homedir } from 'os';
  * Provides an interface to send instructions to the current Tidal instance.
  */
 export interface ITidal {
-    sendTidalExpression(expression: string): Promise<void>;
+    sendTidalExpression(expression: string, echoCommandToLogger?: boolean): Promise<void>;
 }
 
 export class Tidal implements ITidal {
@@ -73,7 +73,7 @@ export class Tidal implements ITidal {
         return true;
     }
 
-    public async sendTidalExpression(expression: string) {
+    public async sendTidalExpression(expression: string, echoCommandToLogger: boolean=false) {
         if (!(await this.bootTidal())) {
             this.logger.error('Could not boot Tidal');
             return;
@@ -82,7 +82,11 @@ export class Tidal implements ITidal {
         this.ghci.writeLn(':{');
         const splits = expression.split(/[\r\n]+/);
         for (let i = 0; i < splits.length; i++) {
-            this.ghci.writeLn(splits[i]);
+            const line = splits[i];
+            if(echoCommandToLogger){
+                this.logger.log(line);
+            }
+            this.ghci.writeLn(line);
         }
         this.ghci.writeLn(':}');
     }

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -41,7 +41,7 @@ suite('Repl', () => {
             mockConfig.object, mockCreateTextEditorDecorationType.object);
         await repl.hush();
 
-        mockTidal.verify(t => t.sendTidalExpression(TypeMoq.It.isAnyString()), TypeMoq.Times.never());
+        mockTidal.verify(t => t.sendTidalExpression(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()), TypeMoq.Times.never());
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.never());
     });
 
@@ -59,7 +59,7 @@ suite('Repl', () => {
             mockConfig.object, mockCreateTextEditorDecorationType.object);
         await repl.executeTemplate("d#s# $ silence");
 
-        mockTidal.verify(t => t.sendTidalExpression('d1 $ silence'), TypeMoq.Times.once());
+        mockTidal.verify(t => t.sendTidalExpression('d1 $ silence', false), TypeMoq.Times.once());
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 
@@ -113,7 +113,7 @@ suite('Repl', () => {
             mockConfig.object, mockCreateTextEditorDecorationType.object);
         await repl.evaluate(true);
 
-        mockTidal.verify(t => t.sendTidalExpression('Foo\r\nbar'), TypeMoq.Times.once());
+        mockTidal.verify(t => t.sendTidalExpression('Foo\r\nbar', false), TypeMoq.Times.once());
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 
@@ -131,7 +131,7 @@ suite('Repl', () => {
             mockConfig.object, mockCreateTextEditorDecorationType.object);
         await repl.evaluate(false);
 
-        mockTidal.verify(t => t.sendTidalExpression('bar'), TypeMoq.Times.once());
+        mockTidal.verify(t => t.sendTidalExpression('bar', false), TypeMoq.Times.once());
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -1,10 +1,11 @@
 import { Position, Selection } from 'vscode';
 import * as TypeMoq from 'typemoq';
 import { createMockDocument, createMockEditor, createMockCreateTextEditorDecorationType } from './mock';
-import { Repl } from '../src/repl';
+import { Repl, splitCommands } from '../src/repl';
 import { ITidal } from '../src/tidal';
 import { IHistory } from '../src/history';
 import { Config } from '../src/config';
+import { assert } from 'chai';
 
 
 suite('Repl', () => {
@@ -133,4 +134,19 @@ suite('Repl', () => {
         mockTidal.verify(t => t.sendTidalExpression('bar'), TypeMoq.Times.once());
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
+
+    test('Command splitting', async () => {
+        let commands = splitCommands("hello\r\nworld");
+
+        assert.isArray(commands);
+        assert.lengthOf(commands, 2);
+        commands.forEach((x, i) => {
+            assert.typeOf(x, 'object', `Expected command ${i} to be an object`);
+            assert.hasAllKeys(x, ["expression","range"], `Expected command ${i} to look like a TidalExpression`);
+        });
+        assert.equal(commands[0].expression, "hello");
+        assert.equal(commands[1].expression, "world");
+        
+    });
+
 });

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -44,6 +44,42 @@ suite('Repl', () => {
         mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.never());
     });
 
+    test('Shortcut executed in .tidal file', async () => {
+        let mockTidal = TypeMoq.Mock.ofType<ITidal>();
+        let mockConfig = TypeMoq.Mock.ofType<Config>();
+        let mockDocument = createMockDocument(['d1 $ Hello world']);
+        let mockEditor = createMockEditor(mockDocument.object, new Selection(new Position(0, 0), new Position(0, 0)));
+        let mockHistory = TypeMoq.Mock.ofType<IHistory>();
+        let mockCreateTextEditorDecorationType = createMockCreateTextEditorDecorationType();
+
+        mockDocument.setup(d => d.fileName).returns(() => 'myfile.tidal');
+
+        let repl = new Repl(mockTidal.object, mockEditor.object, mockHistory.object, 
+            mockConfig.object, mockCreateTextEditorDecorationType.object);
+        await repl.executeTemplate("d#s# $ silence");
+
+        mockTidal.verify(t => t.sendTidalExpression('d1 $ silence'), TypeMoq.Times.once());
+        mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.once());
+    });
+
+    test('Shortcut not executed in non-.tidal file', async () => {
+        let mockTidal = TypeMoq.Mock.ofType<ITidal>();
+        let mockConfig = TypeMoq.Mock.ofType<Config>();
+        let mockDocument = createMockDocument(['d1 $ Hello world']);
+        let mockEditor = createMockEditor(mockDocument.object, new Selection(new Position(0, 0), new Position(0, 0)));
+        let mockHistory = TypeMoq.Mock.ofType<IHistory>();
+        let mockCreateTextEditorDecorationType = createMockCreateTextEditorDecorationType();
+
+        mockDocument.setup(d => d.fileName).returns(() => 'myfile.ideal');
+
+        let repl = new Repl(mockTidal.object, mockEditor.object, mockHistory.object, 
+            mockConfig.object, mockCreateTextEditorDecorationType.object);
+        await repl.executeTemplate("d#s# $ silence");
+
+        mockTidal.verify(t => t.sendTidalExpression(TypeMoq.It.isAnyString()), TypeMoq.Times.never());
+        mockHistory.verify(h => h.log(TypeMoq.It.isAny()), TypeMoq.Times.never());
+    });
+
     test('Expression not evaluated in non-.tidal file', async () => {
         let mockTidal = TypeMoq.Mock.ofType<ITidal>();
         let mockConfig = TypeMoq.Mock.ofType<Config>();

--- a/test/tidal.test.ts
+++ b/test/tidal.test.ts
@@ -4,35 +4,49 @@ import { Logger } from '../src/logging';
 import * as TypeMoq from "typemoq";
 
 suite("Tidal", () => {
-    test("Single line sent to Tidal is passed to GHCi", () => {
-        let mockedLogger = TypeMoq.Mock.ofType<Logger>();
-        let mockedGhci = TypeMoq.Mock.ofType<Ghci>();
-        let tidal: Tidal = new Tidal(mockedLogger.object, mockedGhci.object, null, false);
-        tidal.tidalBooted = true;
-
-        mockedGhci.setup(ghci => ghci.writeLn(':{')).verifiable(TypeMoq.Times.once());
-        mockedGhci.setup(ghci => ghci.writeLn('d1 $ sound "bd"')).verifiable(TypeMoq.Times.once());
-        mockedGhci.setup(ghci => ghci.writeLn(':}')).verifiable(TypeMoq.Times.once());
-
-        return tidal.sendTidalExpression('d1 $ sound "bd"').then(() => {
-            mockedGhci.verifyAll();
-        });
-    });
-
-    ['\r\n', '\n'].forEach(function(lineEnding) {
-        test(`Multiple lines (separator: ${lineEnding}) sent to Tidal are passed to GHCi`, () => {
+    
+    [true, false].forEach(withEcho => {
+        test(`Single line sent to Tidal is passed to GHCi, echo=${withEcho}`, async () => {
             let mockedLogger = TypeMoq.Mock.ofType<Logger>();
             let mockedGhci = TypeMoq.Mock.ofType<Ghci>();
             let tidal: Tidal = new Tidal(mockedLogger.object, mockedGhci.object, null, false);
             tidal.tidalBooted = true;
 
             mockedGhci.setup(ghci => ghci.writeLn(':{')).verifiable(TypeMoq.Times.once());
-            mockedGhci.setup(ghci => ghci.writeLn('d1 $')).verifiable(TypeMoq.Times.once());
-            mockedGhci.setup(ghci => ghci.writeLn('sound "bd"')).verifiable(TypeMoq.Times.once());
+            mockedGhci.setup(ghci => ghci.writeLn('d1 $ sound "bd"')).verifiable(TypeMoq.Times.once());
             mockedGhci.setup(ghci => ghci.writeLn(':}')).verifiable(TypeMoq.Times.once());
 
-            return tidal.sendTidalExpression(`d1 $${lineEnding}sound "bd"`).then(() => {
+            if(withEcho){
+                mockedLogger.setup(logger => logger.log('d1 $ sound "bd"')).verifiable(TypeMoq.Times.once());
+            }
+
+            return tidal.sendTidalExpression('d1 $ sound "bd"').then(() => {
                 mockedGhci.verifyAll();
+            });
+        });
+    });
+
+    [true, false].forEach(withEcho => {
+        ['\r\n', '\n'].forEach(function(lineEnding) {
+            test(`Multiple lines (separator: ${lineEnding}) sent to Tidal are passed to GHCi, echo=${withEcho}`, async () => {
+                let mockedLogger = TypeMoq.Mock.ofType<Logger>();
+                let mockedGhci = TypeMoq.Mock.ofType<Ghci>();
+                let tidal: Tidal = new Tidal(mockedLogger.object, mockedGhci.object, null, false);
+                tidal.tidalBooted = true;
+
+                mockedGhci.setup(ghci => ghci.writeLn(':{')).verifiable(TypeMoq.Times.once());
+                mockedGhci.setup(ghci => ghci.writeLn('d1 $')).verifiable(TypeMoq.Times.once());
+                mockedGhci.setup(ghci => ghci.writeLn('sound "bd"')).verifiable(TypeMoq.Times.once());
+                mockedGhci.setup(ghci => ghci.writeLn(':}')).verifiable(TypeMoq.Times.once());
+
+                if(withEcho){
+                    mockedLogger.setup(logger => logger.log('d1 $')).verifiable(TypeMoq.Times.once());
+                    mockedLogger.setup(logger => logger.log('sound "bd"')).verifiable(TypeMoq.Times.once());
+                }
+
+                return tidal.sendTidalExpression(`d1 $${lineEnding}sound "bd"`).then(() => {
+                    mockedGhci.verifyAll();
+                });
             });
         });
     });


### PR DESCRIPTION
Hi Kindohm,

since I'm a lazy person I don't like to unnecessarily jump around the code or type out the same things over and over again. That's why I've implemented generic keyboard shortcuts for the vscode extension.

The idea is, much like with `hush`, to execute some Tidal (or rather Haskell) commands upon certain key presses. There is a bit of additional logic though that tries to determine the stream number of the statements the cursor is currently in. This allows e.g. to silence the current stream by just pressing some magic key combination, say `cmd+t+cmd+h`. Also mute, solo etc work like this.

Here's an example: Say you would execute the two statements below. Then you'd put your cursor at position 1 and execute the default shortcut 2 (mute). In the background the command `mute 1` would be sent to GHCi. Now, if you move the cursor to `position 2` and execute the default shortcut 4 (solo) the command `solo 3` would be sent.

```
d1
  $ jux rev
  $ s "hh(<3 5 7>,8)" -- position 1

d3
 $ s "bd!4" -- position 2
```

The stream number is currently determined by scanning for something that looks like `d[NUMBER]` and is on the first line of the code block and not indented. This is pretty rudimentary but probably works in 99% of all cases.

Let me know if you think this is useful and if I should amend something.

Cheers, oscons