### PR TITLE
Fix bug in splitCommand

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -188,7 +188,7 @@ export function splitCommands(
 
         return command.cmd.split(/\r?\n/)
             .map(line => ({
-                matched: line.length > 0 && !line.match(/^(\s)|(\s*--)/)
+                matched: line.length > 0 && !line.match(/^((\s)|(\s*--))/)
                 , line
             }))
             .reduce((expressions, {matched, line}) => {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -186,30 +186,26 @@ export function splitCommands(
         that line.
         */
 
-        const lines = command.cmd.split(/\r?\n/);
-        let startLine = 0;
-        
-        const expressions:TidalExpression[] = [];
-
-        for(let i=0;i<lines.length;i++){
-            if(lines[i].length === 0){
-                continue;
-            }
-            let c = lines[i].charAt(0);
-            let m = c.match(/\S/);
-            let isEmpty = typeof m === 'undefined' || m === null || m.length === 0;
-            if(i !== lines.length - 1){
-                if(isEmpty){
-                    continue;
+        return command.cmd.split(/\r?\n/)
+            .map(line => ({
+                matched: line.length > 0 && !line.match(/^(\s)|(\s*--)/)
+                , line
+            }))
+            .reduce((expressions, {matched, line}) => {
+                if(matched){
+                    expressions.push([]);
                 }
-            }
-            let currentCommand = lines.slice(startLine, i+1).reduce((x,y)=>x+"\r\n"+y);
-            startLine = i+1;
-
-            let commandRange = typeof command.range === 'undefined' ? new vscode.Range(0, 0, 0, 0) : command.range;
-            expressions.push(new TidalExpression(currentCommand, commandRange));
-        }
-        return expressions;
+                const current = expressions.pop();
+                if(typeof current !== 'undefined'){
+                    current.push(line);
+                    expressions.push(current);
+                }
+                return expressions;
+            }, [] as (string[])[])
+            .map(lines => {
+                let commandRange = typeof command.range === 'undefined' ? new vscode.Range(0, 0, 0, 0) : command.range;
+                return new TidalExpression(lines.join("\r\n"), commandRange);
+            });
     })
     .reduce((x, y) => {y.forEach(z => x.push(z)); return x;}, []);
 }

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -136,7 +136,7 @@ suite('Repl', () => {
     });
 
     test('Command splitting', async () => {
-        let commands = splitCommands("hello\r\nworld\r\n  foo\r\n    bar\r\n  baz\r\nlast");
+        let commands = splitCommands("hello -- comment\r\nworld -- comment\r\n  foo\r\n    bar\r\n  baz\r\nlast");
 
         assert.isArray(commands);
         assert.lengthOf(commands, 3);
@@ -144,9 +144,15 @@ suite('Repl', () => {
             assert.typeOf(x, 'object', `Expected command ${i} to be an object`);
             assert.hasAllKeys(x, ["expression","range"], `Expected command ${i} to look like a TidalExpression`);
         });
-        assert.equal(commands[0].expression, "hello");
-        assert.equal(commands[1].expression, "world\r\n  foo\r\n    bar\r\n  baz");
+        assert.equal(commands[0].expression, "hello -- comment");
+        assert.equal(commands[1].expression, "world -- comment\r\n  foo\r\n    bar\r\n  baz");
         assert.equal(commands[2].expression, "last");
+
+        commands = splitCommands("hello -- comment\r\n  something");
+        assert.isArray(commands);
+        assert.lengthOf(commands, 1);
+        assert.equal(commands[0].expression, "hello -- comment\r\n  something");
+
     });
 
     test('Template replacements', async () => {

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -136,17 +136,17 @@ suite('Repl', () => {
     });
 
     test('Command splitting', async () => {
-        let commands = splitCommands("hello\r\nworld");
+        let commands = splitCommands("hello\r\nworld\r\n  foo\r\n    bar\r\n  baz\r\nlast");
 
         assert.isArray(commands);
-        assert.lengthOf(commands, 2);
+        assert.lengthOf(commands, 3);
         commands.forEach((x, i) => {
             assert.typeOf(x, 'object', `Expected command ${i} to be an object`);
             assert.hasAllKeys(x, ["expression","range"], `Expected command ${i} to look like a TidalExpression`);
         });
         assert.equal(commands[0].expression, "hello");
-        assert.equal(commands[1].expression, "world");
-        
+        assert.equal(commands[1].expression, "world\r\n  foo\r\n    bar\r\n  baz");
+        assert.equal(commands[2].expression, "last");
     });
 
     test('Template replacements', async () => {


### PR DESCRIPTION
I've found a bug that I had in the function that splits up multiple top level commands. It didn't work properly for multi-line commands that were not at the start of the document.

I've fixed the bug and extended the tests for the function. Would be glad if you could merge this as well @kindohm, as it affects the examples in the hover/code completion.