### PR TITLE
More and easier to create documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,26 @@ Available levels for both options are:
                            information
  * `MINIMUM`: Only show command format information
 
-**Note**: Not every command is documented yet and the detail level of the
-documentation varies from command to command. The files
-[commands.yaml](commands.yaml) and [commands-generated.yaml](commands-generated.yaml)
-contain the currently available documentation. If you'd like to contribute,
-please add new documentation to [commands.yaml](commands.yaml).
+#### Writing new documentation
+
+Not every command is documented yet and the detail level of the documentation
+varies from command to command. The files [commands.yaml](commands.yaml) and
+[commands-generated.yaml](commands-generated.yaml) contain the currently
+available documentation. If you'd like to contribute, please add new
+documentation to [commands.yaml](commands.yaml).
+
+The easiest way to do this is by creating a new file and adding it to the
+`tidalcycles.codehelp.commands.extra` list. The files in this list will be read
+in addition to the defaults contained in the extension itself. This way you can
+start writing and using documentation without actually having to re-compile the
+extension.
+
+For the format take a look at the existing documentation and the source code.
+Most fields support MarkDown syntax as well, so you can style them.
+
+If you want to see how your documentation looks, simply reload the file by
+executing the `tidal.codehelp.reload`. Look out for error messages popping up
+and if there are none you should see your changes immediately.
 
 ### Full Config Example
 

--- a/commands.yaml
+++ b/commands.yaml
@@ -15,10 +15,10 @@ slow:
     - url: https://tidalcycles.org/index.php/fast
       title: Fast - Tidal Documentation
   examples:
-    - 'd1 $ slow 4 $ s "bd!8"'
-    - 'd1 $ s "bd!8" # speed (slow 2 $ range 0.95 1.05 square)'
-    - 'd1 $ fast 4 $ s "bd!2"'
-    - 'd1 $ s "bd!8" # speed (fast 2 $ range 0.95 1.05 square)'
+    - 'd1 $ slow 4 $ s "hh!32"'
+    - 'd1 $ fast 4 $ s "hh!2"'
+    - 'd1 $ s "hh!8" # speed (slow 2 $ range 0.5 (3/2) square)'
+    - 'd1 $ s "hh!8" # speed (fast 2 $ range (1/2) 1.5 square)'
 fast:
   alias: slow
 stut:
@@ -54,11 +54,13 @@ setcps:
   links:
     - https://tidalcycles.org/index.php/Tutorial
 sound:
-  cmd: sound cpattern
+  cmd:
+    - sound cpattern
+    - s cpattern
   help: |-
-    Set a sound pattern. The command can be abbreviated as `s`. The pattern for
-    sounds is `soundname:number`. If `:number` is omitted a default of `0`
-    is assumed. 
+    Define a sound pattern. The command can be abbreviated as `s`. The pattern
+    for sounds is `soundname:number`. If `:number` is omitted a default of `0`
+    is assumed if this pattern is the structure generating pattern.
 
     The sound can be either a sample or a SuperCollider synthesizer name. If
     it's a sample then `soundname` specifies the folder the sample is located
@@ -72,18 +74,20 @@ sound:
   examples:
     - 'd1 $ sound "bd"'
     - 'd1 $ s "bd:18*2 sd:1 bd:10 sd"'
-    - 'd1 $ note "18*2 1 10 [0 0]" # s "bd sd bd sd" -- note the sligthly different ending'
+    - 'd1 $ note "18*2 1 10 [0 0]" # s "bd sd bd sd" -- note the slightly different ending'
   links:
     - https://tidalcycles.org/index.php/sound
-note:
+s:
+  alias: sound
+n:
   cmd: note cpattern
   help: |-
     Creates a note pattern. Depending on where and how it's used it either
     provides structure or just changes the note values in an existing control
     pattern.
   examples:
-    - 'd1 $ note "0 0 0 0" # sound "bd"'
-    - 'd1 $ note "0 1 2 3" # sound "supersaw"'
+    - 'd1 $ n "0 0 0 0" # sound "bd"'
+    - 'd1 $ n "0 1 2 3" # sound "supersaw"'
     - 'd1 $ n "0 1 2 3" # sound "arpy"'
     - 'd1 $ sound "alphabet alphabet alphabet alphabet ~ ~" # n "0 2 3 2 ~ ~" # cut 1' 
 hush:
@@ -107,7 +111,7 @@ solo:
     - solo streamno
     - unsolo streamno
   help: |-
-    Set ur unset the `solo` flag on a stream. If at least one stream has `solo`
+    Set or unset the `solo` flag on a stream. If at least one stream has `solo`
     set only streams with `solo` enabled are audible.
 
     Stacks with `mute`. Only streams that are not `mute`d are audible, even if
@@ -224,12 +228,12 @@ chop:
     cycle this compresses the sample and if it's shorter than a cycle it spreads
     it (though the gaps are not filled). Both is without pitch shifting.
 
-      * `cut 1` plays the whole sample at the beginning of the cycle
-      * `cut 2` plays the first half of the sample at the beginning of the
+      * `chop 1` plays the whole sample at the beginning of the cycle
+      * `chop 2` plays the first half of the sample at the beginning of the
         cycle and the second half of the sample at half of the cycle
-      * `cut 3` plays the first third of the sample at the beginning of the
+      * `chop 3` plays the first third of the sample at the beginning of the
         cycle, the second after the first third of the cycle and the third
-        third of the sampe at two thirds into the cycle.
+        third of the sample at two thirds into the cycle.
     
     Note that `chop` affects `begin` and `end` of the sample.
 
@@ -238,8 +242,9 @@ chop:
     - 'd1 $ chop 2 $ s "xmas" # speed 2 -- notice the two distinct sample parts being played'
     - 'd1 $ chop 16 $ s "xmas" # speed 2 -- sounds still choppy, but smoother'
     - 'd1 $ chop 64 $ s "xmas" # speed 2 -- sounds quite robotic, but somewhat recognizable 1/2 cycle in length'
-    - 'd1 $ s "xmas" # speed 0.5 # cut 1 -- sample longer than 1/2 cycle, cut off'
-    - 'd1 $ chop 32 $ s "xmas" # speed 0.5 # cut 1 -- sample "fits" in 1/2 cycle without pitch shift'
+    - 'd1 $ s "xmas" # speed 0.5 # cut 1 -- sample longer than 1 cycle, cut off'
+    - 'd1 $ chop 32 $ s "xmas" # speed 0.5 -- sample "fits" in 1 cycle without pitch shift'
+    - 'd1 $ chop 32 $ s "xmas!2" # speed 0.5 -- sample "fits" in 1/2 cycle without pitch shift'
 striate:
   cmd:
     - striate noparts cpattern
@@ -294,10 +299,11 @@ speed:
     - 'd1 $ s "numbers:0" # speed 2 # cut 1'
   links:
     - https://tidalcycles.org/index.php/speed
+    - https://tidalcycles.org/index.php/unit
 unit:
   cmd: 'cpattern # unit type'
   help: |-
-    Changes the intrepretation of the `speed` value.
+    Changes the interpretation of the `speed` value.
   params:
     type: |-
       One of `r` for sample length (default), `c` for the cycle length, `s` absolute seconds
@@ -315,19 +321,194 @@ unit:
             , s "cr:0 ~!3" # speed (3/8) # gain 0.8 # unit "r"
             , s "breaks165!4" # speed 1 # unit "c"
         ] 
-# off:
+superimpose:
+  cmd:
+    - superimpose function cpattern
+    - off time function cpattern
+  help: |-
+    Overlay a modified version of the pattern. For `superimpose` does not shift
+    the pattern, so both will be played at exactly the same time, while `off`
+    shifts the modified pattern by some offset.
+  params:
+    function: A function to apply to the pattern to modify it
+    time: A time pattern that defines how the modified pattern is shifted from
+      the original.
+  examples:
+    - 'd1 $ superimpose (# speed 0.5) $ s "arpy!2"'
+    - 'd1 $ off 0 (# speed 0.5) $ s "arpy!2" -- same as above'
+    - 'd1 $ off (-1/16) (# speed 0.5) $ s "arpy!2"'
+    - |- 
+      d1 $ fast 2 $ -- phase music
+        off (slow 256 $ range (-1) 1 tri) (# speed 0.5) $ s "arpy"
+    - |-
+      d1 $ fast 2 $ off (-1/32) -- imitate hitting some chord notes realy
+        (# note "c4 <c3 es3>")  -- the earlier notes
+        (note "c5 <es4 c5>" # s "arpy") -- the original notes
+  links:
+    - https://tidalcycles.org/index.php/superimpose
+    - https://tidalcycles.org/index.php/off
+off:
+  alias: superimpose
+run:
+  cmd: run number
+  help:
+    Generates a pattern of one cycle length of consecutive, ascending numbers
+    starting from 1 up to the specified `number`.
+  examples:
+    - 'd1 $ n (run 8) $ s "hh"'
+    - 'd1 $ up (run 8) $ s "hh"'
+    - 'd1 $ s "bass:1!4" # lpf 800 # resonance (slow 4 $ run 8 |*| (1/8) * 0.3) # cut 1'
+quantise:
+  cmd: quantise num function
+  help: |-
+    Limit values in a function to `num` equally spaced values. The `num`
+    parameter is not a hard-and-fast value, see examples.
+  params:
+    num: The number of discrete values. Actual values of the function will be
+      assigned to the nearest lower discrete value.
+    function: The function to quantise.
+  examples:
+    - 'd1 $ s "arpy!16" # speed (range 1 2 sine) -- every event has a distinct value'
+    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 1 2 sine) -- there''s only two values now'
+    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 1 2.4 sine) -- three values'
+    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 0.5 2.4 sine) -- four values'
+    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 2 2.4 sine) -- one values'
+    - 'd1 $ s "arpy!16" # speed (quantise 6 $ range 2 2.4 sine) -- three values'
+    - 'd1 $ s "arpy!32" # speed (quantise 32 $ range 2 2.4 sine) -- a lot of values'
+euclid:
+  cmd: euclid num parts cpattern
+  help:
+    Distribute `num` reoccurrences of a pattern evenly over `parts` slices of a
+    cycle. 
+  param:
+    num: The number of reoccurrences of the pattern. Should be less than
+      `parts`. Can be a pattern as well.
+    parts: The number of slices to divide the cycle into. The `num`
+      reoccurrences will be placed at the beginning of the parts. Can be a
+      pattern as well.
+  examples:
+    - 'd1 $ euclid 3 8 $ s "bd hh!3"'
+    - 'd1 $ euclid 5 8 $ s "bd hh!3"'
+    - |-
+      d1 $ superimpose
+        ((slow 4) . (euclid 3 8) . (# speed 2))
+        (euclid 3 8 $ s "lt:5")
+    - |-
+      d1 $ stack [
+        euclid "<3 5 3 [7, 13]>" "<8 8 8 16>" $ s "bd" # shape 0.3
+        , juxBy 0.3 (rev) $ euclid "<9 11>" 16 $ s "db"
+        , euclid "[5, <7 6>]" 8 $ s "sn:2" # gain 0.75
+        ]
+  links:
+    - https://tidalcycles.org/index.php/euclid
+    - https://en.wikipedia.org/wiki/Euclidean_rhythm
+sine:
+  cmd:
+    - sine 
+    - saw
+    - square
+    - tri
+  help:
+    Generate a value according to one of the shape functions. The frequency is
+    one per cycle, use `slow` or `fast` to change it. The values are between
+    `0` and `1`, both exclusive for all except square. The interval can be
+    scaled using the `range` function. Sine starts around 0.5, square at 0 and all
+    others at slightly more than 0
+
+    The generated values are continuously changing. You can get sample and
+    hold like behavior by 
+  examples:
+    - 'd1 $ s "hh!16" # speed (saw |+| 1)'
+    - 'd1 $ fast 2 $ s "numbers" # n (slow 2 $ square)'
+    - |-
+      d1 $ fast 2 $ n "0 [~ 0]" # s "bass:3" # cut 1
+        # lpf (slow 8 $ range 600 1000 $ sine)
+saw:
+  alias: sine
+square:
+  alias: sine
+tri:
+  alias: sine
+rand:
+  cmd: rand
+  help: |-
+    Generate a random number between 0 and 1. Use `range` to adjust the range
+    of values.
+
+    `rand` produces random numbers not over time but by invocation. So the
+    `n`-th invocation will always have the same value, no matter where in the
+    cycle it is:
+    ~~~~
+    n "0!4" # n (rand) -- run and check your TidalCycles output
+    n "0!8" # n (rand) -- run and compare the TidalCycles output with the previous one
+    ~~~~
+
+    Due to the implementation of TidalCycles the random values generated by all
+    `rand` calls that have the same offset have exactly the same sequence values.
+    If you want unique random values in various points in your patterns, the
+    easiest workaround is to shift the `rand` function around:
+    ~~~~
+    n "0!4" # n (rand) # gain (rand) -- speed and gain have the same values
+    n "0!8" # n (rand) # gain ((0.1 ~>) rand) -- speed and gain now have different values
+    ~~~~
+  examples:
+    - 'd1 $ s "hh!16" # gain (rand |+| 0.5)'
+    - |-
+      d1 $ stut 3
+            (range 0.02 0.8 rand)
+            (range (1/16) (3/16) square)
+          $ s "sn:2!4"
+irand:
+  cmd: irand number
+  help:
+    Generate random integer numbers between 0 and `number - 1`.
+  params:
+    number: The upper, exclusive bound for the random numbers.
+  examples:
+    - 'd1 $ s "arpy!4" # n (irand 4)'
+    - |-
+      d1 $ stut (irand 4)
+            (irand 10 |/| 20 |+| 0.3)
+            ((irand 3 |+| 1) |*| (1/16))
+          $ s "sn:2!4"
+range:
+  cmd: range lower upper function
+  help:
+    Scales the values of a function. If the values of `function` were in the
+    range of `0` to `1` before they'll be in the range of `lower` to `upper`
+    afterwards.
+
+    If the values of `function` had a different range, then the output won't be
+    scaled to the exact interval of `lower` to `upper`. The formula applied is
+    ~~~~
+    range(x) = function(x) * (upper-lower) + lower
+    ~~~~
+  examples:
+    - 'd1 $ s "arpy!4" # note (range 0 2 square)'
+    - 'd1 $ s "arpy!4" # note (range 0 2 $ range 0 2 square)'
+cut:
+  cmd: 'cpattern # cut n'
+  help:
+    Assigns a cut group to a pattern. All sounds in the cut group are played
+    exclusively with last note priority. That means if a sound in a cut group
+    is currently still playing and a new sound starts, the old one will be
+    stopped.
+  params:
+    n: The cut group number.
+  examples:
+    - 'd1 $ s "numbers:2!4" # speed 0.5'
+    - 'd1 $ s "numbers:2!4" # speed 0.5 # cut 1'
+    - |-
+      d1 $ stack [
+        s "hh:1" # cut 1
+        , fast 4 $ s "~ hh" # cut 1
+        , ((1/128) ~>) $ s "bass!4" # gain 0.7 # cut 2
+        , s "bd!4" # cut 2
+        ]
+
+
 # up:
-# down:
-# run:
-# euclid:
 # samples:
-# sine:
-# saw:
-# square:
-# tri:
-# rand:
-# irand:
-# range:
 # slowcat:
 # cat:
 # fastcat:
@@ -335,6 +516,6 @@ unit:
 # whenmod:
 # const:
 # stack:
-# cut:
+
 # anticipate:
 # xfadeIn:

--- a/commands.yaml
+++ b/commands.yaml
@@ -7,7 +7,7 @@ slow:
     for the pattern to repeat.
   params:
     times: The amount to slow down or speed up the pattern by. Can be a pattern
-            itself.
+      itself.
   returns: A slowed down version of the pattern
   links:
     - url: https://tidalcycles.org/index.php/slow
@@ -82,18 +82,49 @@ s:
 n:
   cmd: note cpattern
   help: |-
-    Creates a note pattern. Depending on where and how it's used it either
-    provides structure or just changes the note values in an existing control
-    pattern.
+    Sets the `n` value in a pattern. If you're using the pattern with a sample
+    the `n` value selects the sample in the folder. If you're using the pattern
+    with a synth sound n
+
+    **Note**: `n` is not an abbreviation for `note`. They both change different
+    parameters of the control patterns.
   examples:
-    - 'd1 $ n "0 0 0 0" # sound "bd"'
+    - 'd1 $ n "1 2 3 4" # sound "numbers" # speed 1.5'
+    - 'd1 $ n "0 1 0 3" # sound "bd sn bd sn"'
     - 'd1 $ n "0 1 2 3" # sound "supersaw"'
-    - 'd1 $ n "0 1 2 3" # sound "arpy"'
-    - 'd1 $ sound "alphabet alphabet alphabet alphabet ~ ~" # n "0 2 3 2 ~ ~" # cut 1' 
+    - 'd1 $ sound "alphabet!4 ~!2" # n "0 2 3 2 ~!" # cut 1' 
+note:
+  cmd:
+    - note cpattern
+    - up cpattern
+  help: |-
+    Set the note pitch. For samples this changes the playback speed.
+
+    You can set the note pitch in the pattern by either using numbers or note
+    names, where `0` and `c5` are the original sample pitch. See the
+    description in the [Tutorial](https://tidalcycles.org/index.php/Tutorial)
+    for more information.
+  examples:
+    - 'd1 $ note "0 1 2 <3 -12>" # sound "hh:9"'
+    - 'd1 $ up "0 1 2 <3 -12>" # sound "hh:9"'
+    - 'd1 $ note "0 c5 f5 [c5 ds5 f4]" # sound "hh:9"'
+    - |-
+      d1 $ note "[0, -12, 12] [c6, ds6, g5]*2 c5 [c6, ds6, g5]"
+        |-| note 12 # sound "supersaw"
+    - |-
+      -- combining note and n can be useful for samples, but has no effect on synths
+      d1 $ note "[0, -12, 12] [c6, ds6, g5]*2 c5 [c6, ds6, g5]"
+        |-| note 12 # (slow 4 $ n "0!2 2 3" # sound "arpy")
+  links:
+    - https://tidalcycles.org/index.php/Tutorial
+up:
+  alias: note
 hush:
   cmd: hush
   help: |-
-    Stop all running streams.
+    Stop all running streams. Is actually a common alias defined in the
+    `TidalBoot.hs` file, so if `hush` does nto work for you, check if and which
+    tidal bootup file is being sourced.
   examples:
     - 'hush'
 silence:
@@ -166,7 +197,7 @@ rev:
     - 'd1 $ every 2 (rev) $ s "bd hh hh lt"'
 every:
   cmd: every numcycles function cpattern
-  help:
+  help: |-
     Apply a `function` to a pattern every `numcycles` cycles, effectively
     replacing the orgiginal pattern with the modified one in that cycle.
   examples:
@@ -185,8 +216,7 @@ crush:
     - 'd1 $ slow 2 $ s "bd!8" # crush (run 8 |+| 1)'
 gain:
   cmd: gain number cpattern
-  help:
-    Apply a gain value to a control pattern.
+  help: Apply a gain value to a control pattern.
   params:
     number: A frational pattern that controls the gain.
   examples:
@@ -194,8 +224,7 @@ gain:
     - 'd1 $ s "hh!8" # gain (fast 2 "1 0.8")'
 pan:
   cmd: 'cpattern # pan number'
-  help:
-    Pan the output of a pattern between left (`0`) and right (`1`).
+  help: Pan the output of a pattern between left (`0`) and right (`1`).
   params:
     number: A fractional pattern that defines how to pan the output.
   examples:
@@ -212,7 +241,7 @@ shape:
     - 'd1 $ s "bd!4" # shape (slow 2 $ range 0 1 saw)'
 vowel:
   cmd: 'cpattern # vowel pattern'
-  help:
+  help: |-
     Shapes a sound to a vowel. Works best with sounds with a low of noise or
     distortion.
   params:
@@ -258,8 +287,8 @@ striate:
     a0 b0 a1 b1 a2 b2 a3 b3
     ~~~~
 
-    Note: If the effect you're going for does not emerge, make sure you're not
-    unintentionally `cut`ing the samples.
+    **Note**: If the effect you're going for does not emerge, make sure you're
+    not unintentionally `cut`ing the samples.
   params:
     noparts: The number of parts to chop the samples into.
     length: The length of each part.
@@ -351,7 +380,7 @@ off:
   alias: superimpose
 run:
   cmd: run number
-  help:
+  help: |-
     Generates a pattern of one cycle length of consecutive, ascending numbers
     starting from 1 up to the specified `number`.
   examples:
@@ -408,7 +437,7 @@ sine:
     - saw
     - square
     - tri
-  help:
+  help: |-
     Generate a value according to one of the shape functions. The frequency is
     one per cycle, use `slow` or `fast` to change it. The values are between
     `0` and `1`, both exclusive for all except square. The interval can be
@@ -460,8 +489,7 @@ rand:
           $ s "sn:2!4"
 irand:
   cmd: irand number
-  help:
-    Generate random integer numbers between 0 and `number - 1`.
+  help: Generate random integer numbers between 0 and `number - 1`.
   params:
     number: The upper, exclusive bound for the random numbers.
   examples:
@@ -473,7 +501,7 @@ irand:
           $ s "sn:2!4"
 range:
   cmd: range lower upper function
-  help:
+  help: |-
     Scales the values of a function. If the values of `function` were in the
     range of `0` to `1` before they'll be in the range of `lower` to `upper`
     afterwards.
@@ -505,17 +533,141 @@ cut:
         , ((1/128) ~>) $ s "bass!4" # gain 0.7 # cut 2
         , s "bd!4" # cut 2
         ]
+whenmod:
+  cmd: whenmod div remainder function cpattern
+  help: |-
+    Apply `function` to `cpattern` every time the current cycle count modulo 
+    `div` is `remainder` **or higher**. `fast` and `slow` affect the cycle count
+    and hence the behavior of `whenmod`.
 
+    This is handy e.g. for drum fills.
+  params:
+    div: The divisor to divide the cycle count by.
+    remainder: The minimum the remainder of the modulo opeation needs to be
+      in order to modify the pattern by `function`
+    function: A function to apply to the pattern.
+  examples:
+    - 'd1 $ fast 4 $ whenmod 4 2 (# speed 2) $ s "arpy"'
+    - 'd1 $ fast 4 $ whenmod 4 1 (# speed 2) $ s "arpy"'
+    - 'd1 $ fast 4 $ whenmod 4 3 (euclid 3 8) $ s "sn:2"'
+    - 'd1 $ fast 4 $ whenmod 4 3 (const "sn:2!3") $ s "sn:2"'
+stack:
+  cmd: stack [ cpatterns ]
+  help: |-
+    Combines the events of an array of control patterns. The patterns can be of
+    different lengths. The patterns can use polyphony or `stack`s themselves.
 
-# up:
-# samples:
-# slowcat:
-# cat:
-# fastcat:
-# degrade:
-# whenmod:
-# const:
-# stack:
+    **Note:** Some functions like some effects (e.g. `delay`) a whole `orbit`
+    not only single patterns. Hence using them in `stack` does not work. If you
+    want different effect values you need to separate your sounds into different
+    streams and/or orbits.
+  examples:
+    - 'd1 $ stack [s "hh!4", fast 2 "bd"]'
+    - |-
+      d1 $ stack [
+          stack [
+              s "bd!2"
+              , stack [
+                      ((1/4) ~>) $ s "hh!2" # gain 1.2
+                      , slow 2 $ s "tablex:1" # unit "c" # speed 0.5
+                  ] # cut 1                      -- same cut group
+              ] # orbit 2                        -- same orbit for the whole stack
+                # room 0.7 # size 0.5 # lpf 6000 -- same fx for the whole orbit
+          , stack [
+              slow 2 $ note "e2 d2" # s "arpy" # crush 6
+              , stut "<1 3>" 0.1 (3/16) $        -- use stut to fake delays
+                  ((1/4) ~>) $ note "[e4, g4, b4]!2" # s "arpy"
+              ] # orbit 1                        -- separate orbit for the whole stack
+                # lpf 1200 # resonance 0.15      -- applies only this orbit
+          ]
+degrade:
+  cmd:
+    - degrade cpattern
+    - degradeBy number cpattern
+  help: |-
+    Randomly drops events from a pattern. `degrade` has a 50% chance of dropping
+    events, with `degradeBy` you can specify a `number` between `0` (don't drop
+    anything) and `1` (drop every event).
+  params:
+    number: The probability between `0` and `1` that an event is going to be
+      dropped.
+  examples:
+    - 'd1 $ degrade $ s "hh!16"'
+    - 'd1 $ degradeBy 0.1 $ s "hh!16"'
+    - 'd1 $ degradeBy (slow 4 $ range 0.1 0.5 tri) $ striate 64 $ s "breaks125"'
+degradeBy:
+  alias: degrade
+const:
+  cmd: const newpattern cpattern
+  help: |-
+    Discard any incoming pattern information and replace with a new pattern.
+    This is handy for when you want to completely replace a patter in a function
+    like `every`.
+  params:
+    newpattern: The new control pattern.
+  examples:
+    - 'd1 $ const (s "hh!4") $ s "bd!4" # gain "1 0 1 0"'
+    - 'd1 $ every 2 (const $ s "sn(11,16)") $ s "bd!4"'
+samples:
+  cmd: samples sound number
+  help: |-
+    Lets you set the `s` and `n` parameter on a pattern separately.
+  params:
+    sound: A pattern specifying the sounds to play.
+    number: A number or function that specifies the sample to pick from the
+      sound folder.
+  examples:
+    - 'd1 $ sound $ samples "drum*4" (run 4)'
+xfade:
+  cmd: 
+    - xfade stream cpattern
+    - xfadeIn stream time cpattern
+  help: |-
+    Fade a new pattern into a stream over time. For `xfade` 4 cycles are used.
+    `xfadeIn` let's you specify the number of cycles in the `time` parameter.
 
-# anticipate:
-# xfadeIn:
+    You can use `xfade` to fade out byt just fading to `silence`.
+  params:
+    stream: The number or name of a stream. This has to be the stream name and
+      can't be one of the aliases like `d1` that are set up. For `d1` you would
+      have to use the number 1.
+    time: The number of cycles to take for the fading the new pattern in.
+  examples:
+    - 'xfade 1 $ s "bd!4"'
+    - 'xfade 1 $ stack [ s "bd!8", fast 2 $ s "~ sn:2" ]'
+    - |-
+      xfadeIn 1 8 $ stack [
+        s "bd!4" , s "hh!16"
+        , note "c3!7 c2" # s "arpy" # gain 0.9
+        ]
+xfadeIn:
+  alias: xfade
+slowcat:
+  cmd:
+    - cat [cpatterns]
+    - slowcat [cpatterns]
+    - fastcat [cpatterns]
+  help: |-
+    Concatenates cycles from an array of pattern into combined cycles. `cat` is
+    and alias for `slowcat`.
+
+    For each cycle the patterns in the array are, in order, asked to provide
+    one cycle of events. These one cycles per pattern are then concatenated. In
+    the case of `fastcat` the concatenated pattern is then sped up by the number
+    of patterns in the array, so the new, concatenated cycles spans exactly one
+    cycle. `slowcat` does nto adjust the speed, hence the new pattern will have
+    a length of cycles that's equal to the number of patterns in the array.
+
+    If the patterns have different lengths/speeds their "parts" will be
+    prograssively integrated into the concatenated pattern.
+  examples:
+    - 'd1 $ slowcat [n "0!2", n "1!2"] # s "arpy"'
+    - 'd1 $ cat [n "0!2", n "1!2"] # s "arpy"'
+    - 'd1 $ fastcat [n "0!2", n "1!2"] # s "arpy"'
+    - 'd1 $ fast 2 $ slowcat [n "0!2", n "1!2"] # s "arpy"'
+    - 'd1 $ fastcat [n "0!2", slow 3 $ n "2!2 3!2 4!2"] # s "arpy"'
+    - 'd1 $ fastcat [slow 2 $ n "0!2 1!2", slow 3 $ n "3!2 4!2"] # s "arpy"'
+cat:
+  alias: slowcat
+fastcat:
+  alias: slowcat

--- a/commands.yaml
+++ b/commands.yaml
@@ -1,50 +1,44 @@
 slow:
-  cmd: slow times pattern
-  help:
-    Slow down a pattern. This effectively changes the number of cycles it takes
+  cmd:
+    - slow times cpattern
+    - fast times cpattern
+  help: |-
+    Slows down or speeds up a pattern. This effectively changes the number of cycles it takes
     for the pattern to repeat.
   params:
-    times: The amount to slow down the pattern by. Can be a pattern itself
-    pattern: The pattern to slow down
+    times: The amount to slow down or speed up the pattern by. Can be a pattern
+            itself.
   returns: A slowed down version of the pattern
   links:
     - url: https://tidalcycles.org/index.php/slow
-      title: Tidal Documentation
+      title: Slow - Tidal Documentation
+    - url: https://tidalcycles.org/index.php/fast
+      title: Fast - Tidal Documentation
   examples:
     - 'd1 $ slow 4 $ s "bd!8"'
     - 'd1 $ s "bd!8" # speed (slow 2 $ range 0.95 1.05 square)'
-fast:
-  cmd: fast times pattern
-  help:
-    Speed up a pattern. This effectively changes the number of cycles it takes
-    for the pattern to repeat.
-  params:
-    times: The amount to speed up the pattern by. Can be a pattern itself
-    pattern: The pattern to speed up
-  returns:
-    A sped up version of the pattern
-  links:
-    - url: https://tidalcycles.org/index.php/fast
-      title: Tidal Documentation
-  examples:
     - 'd1 $ fast 4 $ s "bd!2"'
     - 'd1 $ s "bd!8" # speed (fast 2 $ range 0.95 1.05 square)'
+fast:
+  alias: slow
 stut:
-  cmd: stut repeat time decay
-  help:
+  cmd: stut repeat decay time cpattern
+  help: |-
     Similar to a delay, this causes `repeat` versions of the pattern to play
     with an offset of `time` each. Every time the pattern is repeated, the gain
     is multiplied with the `decay` values.
   params:
-    repeat: The number of times to repeat the pattern
-    time: The delay between the repeated patterns
-    decay:
-      The amount to multiply the gain by on each repeat. Values `< 1` will
-      make the repeats more silent each time, values `> 1` will make their
-      volume increase.
+    repeat: An integer pattern that defines the number of times to repeat the
+      control pattern.
+    decay: |-
+      A frational pattern that defines amount to multiply the gain by on each
+      repeat. Values `< 1` will make the repeats more silent each time, values
+      `> 1` will make their volume increase with every repeat.
+    time: A frational that defines the delay between the repeated patterns.
   examples:
-    - 'd1 $ stut 3 (1/3) 0.8 $ s "sd!4"'
-    - 'd1 $ every 2 (stut 3 (1/8) 1.1) $ s "sd!4"'
+    - 'd1 $ slow 2 $ stut 3 0.6 (1/12) $ s "sd!4"'
+    - 'd1 $ every 2 (stut 3 1.3 (1/16)) $ s "sd!4"'
+    - 'd1 $ slow 2 $ stut "<3 6>" "<1.2 0.6>" (1/16) $ s "sd!4"'
 setcps:
   cmd: setcps numcycles
   help: Set the cycles per second that Tidal should evaluate.
@@ -59,3 +53,288 @@ setcps:
       d1 $ s "bd!4"
   links:
     - https://tidalcycles.org/index.php/Tutorial
+sound:
+  cmd: sound cpattern
+  help: |-
+    Set a sound pattern. The command can be abbreviated as `s`. The pattern for
+    sounds is `soundname:number`. If `:number` is omitted a default of `0`
+    is assumed. 
+
+    The sound can be either a sample or a SuperCollider synthesizer name. If
+    it's a sample then `soundname` specifies the folder the sample is located
+    in and `number` is the, alphabetically ordered, position of the sample in
+    that folder. If `soundname` is a synthesizer then `number` is the note
+    number.
+
+    Structure can either come form the pattern itself or for example from a
+    separate `note` instruction, which, depending on the position, can also
+    override the `number` parameter.
+  examples:
+    - 'd1 $ sound "bd"'
+    - 'd1 $ s "bd:18*2 sd:1 bd:10 sd"'
+    - 'd1 $ note "18*2 1 10 [0 0]" # s "bd sd bd sd" -- note the sligthly different ending'
+  links:
+    - https://tidalcycles.org/index.php/sound
+note:
+  cmd: note cpattern
+  help: |-
+    Creates a note pattern. Depending on where and how it's used it either
+    provides structure or just changes the note values in an existing control
+    pattern.
+  examples:
+    - 'd1 $ note "0 0 0 0" # sound "bd"'
+    - 'd1 $ note "0 1 2 3" # sound "supersaw"'
+    - 'd1 $ n "0 1 2 3" # sound "arpy"'
+    - 'd1 $ sound "alphabet alphabet alphabet alphabet ~ ~" # n "0 2 3 2 ~ ~" # cut 1' 
+hush:
+  cmd: hush
+  help: |-
+    Stop all running streams.
+  examples:
+    - 'hush'
+silence:
+  cmd: silence
+  help: |-
+    Silence generates an empty control pattern, effectively muting the stream.
+  examples:
+    - |-
+      d1 $ s "db!4"
+      xfadeIn 1 2 $ silence
+  links:
+    - https://tidalcycles.org/index.php/silence
+solo:
+  cmd:
+    - solo streamno
+    - unsolo streamno
+  help: |-
+    Set ur unset the `solo` flag on a stream. If at least one stream has `solo`
+    set only streams with `solo` enabled are audible.
+
+    Stacks with `mute`. Only streams that are not `mute`d are audible, even if
+    they have `solo` enabled.
+
+    Use [list](command:tidal.help?cmd=list) to view the current state of solo
+    and mute for each stream.
+  params:
+    streamno: The number of the stream to solo/unsolo. Note that it has to be a
+      number like `1` and can't be a stream alias like `d1`.
+  examples:
+    - |-
+      d1 $ fast 2 $ s "bd ~"
+      d2 $ fast 2 $ s "~ sn:1"
+      d3 $ s "hh!15 hh*3" # (fast 3 $ gain "1 <0.8 0.9 0.85>!3")
+      solo 3 -- only play hihats
+    - solo 2 -- add the snare back
+    - unsolo 3 -- remove the hihats
+    - list -- check tidal cycles output
+    - unsolo 2 -- play all streams again
+unsolo:
+  alias: solo
+mute:
+  cmd:
+    - mute streamno
+    - unmute streamno
+  help: |-
+    Mutes or unmutes a stream. This takes precedence over `solo` in that a muted
+    stream still does not play, even if it's `solo`ed.
+
+    Use [list](command:tidal.help?cmd=list) to view the current state of solo
+    and mute for each stream.
+  params:
+    streamno: The number of the stream to mute/unmute. Note that it has to be a
+      number like `1` and can't be a stream alias like `d1`.
+  examples:
+    - |-
+      d1 $ fast 2 $ s "bd ~"
+      d2 $ fast 2 $ s "~  sd"
+      mute 1 -- mute the bass drum
+    - 'mute 2 -- mute the snare as well'
+    - 'unmute 1 -- unmute the bass drum'
+    - 'list -- check tidal cycles output'
+unmute:
+  alias: mute
+rev:
+  cmd: rev cpattern
+  help: |-
+    Reverse a control pattern.
+  examples:
+    - 'd1 $ rev $ s "bd hh hh lt"'
+    - 'd1 $ every 2 (rev) $ s "bd hh hh lt"'
+every:
+  cmd: every numcycles function cpattern
+  help:
+    Apply a `function` to a pattern every `numcycles` cycles, effectively
+    replacing the orgiginal pattern with the modified one in that cycle.
+  examples:
+    - 'd1 $ every 2 (fast 4) $ s "hh!4"'
+    - 'd1 $ s "hh!8" # pan (every 2 (|+| 1) 0)'
+crush:
+  cmd: 'cpattern # crush strength'
+  help:
+    Apply a bit crushing effect to the stream.
+  parms:
+    strength: A fractional pattern that controls the strength of the bit
+      crushing effect. The numbers should be `>0` with lower numbers causing
+      the effect to be stronger.
+  examples:
+    - 'd1 $ slow 2 $ s "bd!8" # crush 4'
+    - 'd1 $ slow 2 $ s "bd!8" # crush (run 8 |+| 1)'
+gain:
+  cmd: gain number cpattern
+  help:
+    Apply a gain value to a control pattern.
+  params:
+    number: A frational pattern that controls the gain.
+  examples:
+    - 'd1 $ s "hh!8" # gain 0.8'
+    - 'd1 $ s "hh!8" # gain (fast 2 "1 0.8")'
+pan:
+  cmd: 'cpattern # pan number'
+  help:
+    Pan the output of a pattern between left (`0`) and right (`1`).
+  params:
+    number: A fractional pattern that defines how to pan the output.
+  examples:
+    - 'd1 $ s "hh!8" # pan (fast 2 "0 1")'
+    - 'd1 $ s "hh!16" # pan (fast 2 $ range 0 1 saw)'
+shape:
+  cmd: 'cpattern # shape number'
+  help:
+    Apply transient shaping to a pattern.
+  params:
+    number: An fractional pattern 
+  examples:
+    - 'd1 $ s "bd!4" # shape 0.9'
+    - 'd1 $ s "bd!4" # shape (slow 2 $ range 0 1 saw)'
+vowel:
+  cmd: 'cpattern # vowel pattern'
+  help:
+    Shapes a sound to a vowel. Works best with sounds with a low of noise or
+    distortion.
+  params:
+    pattern: A string pattern of vowels to use in the shaping.
+  examples:
+    - 'd1 $ s "bass2:0!4" # vowel "a e i u"'
+    - 'd1 $ s "sn:6!4" # vowel "a e i u"'
+chop:
+  cmd: chop number cpattern
+  help: |-
+    Cut up a sample event into multiple new events, plaing back that portion of
+    the sample at that interval of the cycle. If the sample is longer than a
+    cycle this compresses the sample and if it's shorter than a cycle it spreads
+    it (though the gaps are not filled). Both is without pitch shifting.
+
+      * `cut 1` plays the whole sample at the beginning of the cycle
+      * `cut 2` plays the first half of the sample at the beginning of the
+        cycle and the second half of the sample at half of the cycle
+      * `cut 3` plays the first third of the sample at the beginning of the
+        cycle, the second after the first third of the cycle and the third
+        third of the sampe at two thirds into the cycle.
+    
+    Note that `chop` affects `begin` and `end` of the sample.
+
+    See also [striate](command:tidal.help?cmd=striate) for another way to chop up a sample.
+  examples:
+    - 'd1 $ chop 2 $ s "xmas" # speed 2 -- notice the two distinct sample parts being played'
+    - 'd1 $ chop 16 $ s "xmas" # speed 2 -- sounds still choppy, but smoother'
+    - 'd1 $ chop 64 $ s "xmas" # speed 2 -- sounds quite robotic, but somewhat recognizable 1/2 cycle in length'
+    - 'd1 $ s "xmas" # speed 0.5 # cut 1 -- sample longer than 1/2 cycle, cut off'
+    - 'd1 $ chop 32 $ s "xmas" # speed 0.5 # cut 1 -- sample "fits" in 1/2 cycle without pitch shift'
+striate:
+  cmd:
+    - striate noparts cpattern
+    - striateBy noparts length cpattern
+    - striate' noparts length cpattern
+  help: |-
+    Chop up a sample event and intersperse the parts with other samples in the
+    pattern and cycle. Given two samples `a` and `b` and a total of `4` parts
+    per sample, the sample parts are played like this:
+    ~~~~
+    a0 b0 a1 b1 a2 b2 a3 b3
+    ~~~~
+
+    Note: If the effect you're going for does not emerge, make sure you're not
+    unintentionally `cut`ing the samples.
+  params:
+    noparts: The number of parts to chop the samples into.
+    length: The length of each part.
+  examples:
+    - 'd1 $ striate 16 $ sound "numbers:0 numbers:2 numbers:3" # speed 0.5'
+    - |-
+      d1 $ striate' 8 (1/32) $ sound "numbers:0 numbers:2 numbers:3" # speed 0.5
+    - |-
+      d1 $ striate 8 $ s "breaks125:0 breaks125:1"
+        # unit "c" # speed 1 -- makes the samples exactly one cycle long
+    - 'd1 $ striate 16 $ s "breaks125:0 breaks125:1" # unit "c" # speed 1 -- notice how the loop feels different'
+  links:
+    - https://tidalcycles.org/index.php/striate
+striateBy:
+  alias: striate
+striate':
+  alias: striate
+speed:
+  cmd: 'cpattern # speed number'
+  help: |-
+    Change the speed of the samples in the pattern. Changing the speed
+    effectively changes the pitch, so if you want to pitch a sample up or down
+    by an octave (depending on your tuning scheme) you can set the pitch to `2`
+    or `1/2`.
+    
+    Changing the speed also affects the sample length. Together with
+    [unit](command:tidal.help?cmd=unit) you can e.g. speed up and slow down the
+    sample to be a multiple of your cycle length.
+  params:
+    number: A pattern of fractionals that define the speed of the samples.
+      Values less than 1 slow down the sample, above 1 they speed it up.
+      Negative values cause the sample to be played in reverse.
+  examples:
+    - 'd1 $ s "numbers:0" # speed 2 # cut 1'
+    - 'd1 $ s "numbers:0" # speed 0.5 # cut 1'
+    - 'd1 $ n "0!8" # s "numbers" # speed (range 0.5 1.5 saw) # cut 1'
+    - 'd1 $ s "numbers:0" # speed 2 # cut 1'
+  links:
+    - https://tidalcycles.org/index.php/speed
+unit:
+  cmd: 'cpattern # unit type'
+  help: |-
+    Changes the intrepretation of the `speed` value.
+  params:
+    type: |-
+      One of `r` for sample length (default), `c` for the cycle length, `s` absolute seconds
+  examples:
+    - |-
+      setcps (74/60/4)
+      d1 $ s "breaks125" # unit "c" # gain 0.6
+      d2 $ s "hh!4" # gain "1.2 0.75 1 0.75"
+    - 'setcps (160/60/4) -- now go faster, notice how the pitch of the hihats stays the same'
+    - |-
+      setcps (125/60/4)
+      d1 $ slow 4 $
+        stack [
+            s "~!2 ho:2 ~" # speed (-1/2) # gain 0.7 # unit "c"
+            , s "cr:0 ~!3" # speed (3/8) # gain 0.8 # unit "r"
+            , s "breaks165!4" # speed 1 # unit "c"
+        ] 
+# off:
+# up:
+# down:
+# run:
+# euclid:
+# samples:
+# sine:
+# saw:
+# square:
+# tri:
+# rand:
+# irand:
+# range:
+# slowcat:
+# cat:
+# fastcat:
+# degrade:
+# whenmod:
+# const:
+# stack:
+# cut:
+# anticipate:
+# xfadeIn:

--- a/commands.yaml
+++ b/commands.yaml
@@ -31,10 +31,10 @@ stut:
     repeat: An integer pattern that defines the number of times to repeat the
       control pattern.
     decay: |-
-      A frational pattern that defines amount to multiply the gain by on each
+      A fractional pattern that defines amount to multiply the gain by on each
       repeat. Values `< 1` will make the repeats more silent each time, values
       `> 1` will make their volume increase with every repeat.
-    time: A frational that defines the delay between the repeated patterns.
+    time: A fractional that defines the delay between the repeated patterns.
   examples:
     - 'd1 $ slow 2 $ stut 3 0.6 (1/12) $ s "sd!4"'
     - 'd1 $ every 2 (stut 3 1.3 (1/16)) $ s "sd!4"'
@@ -123,7 +123,7 @@ hush:
   cmd: hush
   help: |-
     Stop all running streams. Is actually a common alias defined in the
-    `TidalBoot.hs` file, so if `hush` does nto work for you, check if and which
+    `TidalBoot.hs` file, so if `hush` does not work for you, check if and which
     tidal bootup file is being sourced.
   examples:
     - 'hush'
@@ -158,9 +158,9 @@ solo:
       d1 $ fast 2 $ s "bd ~"
       d2 $ fast 2 $ s "~ sn:1"
       d3 $ s "hh!15 hh*3" # (fast 3 $ gain "1 <0.8 0.9 0.85>!3")
-      solo 3 -- only play hihats
+      solo 3 -- only play hi-hats
     - solo 2 -- add the snare back
-    - unsolo 3 -- remove the hihats
+    - unsolo 3 -- remove the hi-hats
     - list -- check tidal cycles output
     - unsolo 2 -- play all streams again
 unsolo:
@@ -199,7 +199,7 @@ every:
   cmd: every numcycles function cpattern
   help: |-
     Apply a `function` to a pattern every `numcycles` cycles, effectively
-    replacing the orgiginal pattern with the modified one in that cycle.
+    replacing the original pattern with the modified one in that cycle.
   examples:
     - 'd1 $ every 2 (fast 4) $ s "hh!4"'
     - 'd1 $ s "hh!8" # pan (every 2 (|+| 1) 0)'
@@ -218,7 +218,7 @@ gain:
   cmd: gain number cpattern
   help: Apply a gain value to a control pattern.
   params:
-    number: A frational pattern that controls the gain.
+    number: A fractional pattern that controls the gain.
   examples:
     - 'd1 $ s "hh!8" # gain 0.8'
     - 'd1 $ s "hh!8" # gain (fast 2 "1 0.8")'
@@ -252,7 +252,7 @@ vowel:
 chop:
   cmd: chop number cpattern
   help: |-
-    Cut up a sample event into multiple new events, plaing back that portion of
+    Cut up a sample event into multiple new events, playing back that portion of
     the sample at that interval of the cycle. If the sample is longer than a
     cycle this compresses the sample and if it's shorter than a cycle it spreads
     it (though the gaps are not filled). Both is without pitch shifting.
@@ -341,7 +341,7 @@ unit:
       setcps (74/60/4)
       d1 $ s "breaks125" # unit "c" # gain 0.6
       d2 $ s "hh!4" # gain "1.2 0.75 1 0.75"
-    - 'setcps (160/60/4) -- now go faster, notice how the pitch of the hihats stays the same'
+    - 'setcps (160/60/4) -- now go faster, notice how the pitch of the hi-hats stays the same'
     - |-
       setcps (125/60/4)
       d1 $ slow 4 $
@@ -407,13 +407,13 @@ quantise:
 euclid:
   cmd: euclid num parts cpattern
   help:
-    Distribute `num` reoccurrences of a pattern evenly over `parts` slices of a
+    Distribute `num` re-occurrences of a pattern evenly over `parts` slices of a
     cycle. 
   param:
-    num: The number of reoccurrences of the pattern. Should be less than
+    num: The number of re-occurrences of the pattern. Should be less than
       `parts`. Can be a pattern as well.
     parts: The number of slices to divide the cycle into. The `num`
-      reoccurrences will be placed at the beginning of the parts. Can be a
+      re-occurrences will be placed at the beginning of the parts. Can be a
       pattern as well.
   examples:
     - 'd1 $ euclid 3 8 $ s "bd hh!3"'
@@ -543,7 +543,7 @@ whenmod:
     This is handy e.g. for drum fills.
   params:
     div: The divisor to divide the cycle count by.
-    remainder: The minimum the remainder of the modulo opeation needs to be
+    remainder: The minimum the remainder of the modulo operation needs to be
       in order to modify the pattern by `function`
     function: A function to apply to the pattern.
   examples:
@@ -655,11 +655,11 @@ slowcat:
     one cycle of events. These one cycles per pattern are then concatenated. In
     the case of `fastcat` the concatenated pattern is then sped up by the number
     of patterns in the array, so the new, concatenated cycles spans exactly one
-    cycle. `slowcat` does nto adjust the speed, hence the new pattern will have
+    cycle. `slowcat` does not adjust the speed, hence the new pattern will have
     a length of cycles that's equal to the number of patterns in the array.
 
     If the patterns have different lengths/speeds their "parts" will be
-    prograssively integrated into the concatenated pattern.
+    progressively integrated into the concatenated pattern.
   examples:
     - 'd1 $ slowcat [n "0!2", n "1!2"] # s "arpy"'
     - 'd1 $ cat [n "0!2", n "1!2"] # s "arpy"'

--- a/commands.yaml
+++ b/commands.yaml
@@ -390,20 +390,26 @@ run:
 quantise:
   cmd: quantise num function
   help: |-
-    Limit values in a function to `num` equally spaced values. The `num`
-    parameter is not a hard-and-fast value, see examples.
+    Limit values in a function to `num` equally spaced values, if the function
+    returns values between `0` (inclusive) and `1` (exclusive). `quantize 1`
+    will return two values instead of one for that range. Keep in mind that
+    `saw`, `tri` and `sine` don't reach the value `1`.
+
+    For values outside the range of `0` to `1` it'll still generate quantized
+    values but it'll be `(upper-lower)*num+1` values that are spaced equally
+    between `lower` (inclusive) and `upper` (inclusive).
   params:
     num: The number of discrete values. Actual values of the function will be
       assigned to the nearest lower discrete value.
     function: The function to quantise.
   examples:
-    - 'd1 $ s "arpy!16" # speed (range 1 2 sine) -- every event has a distinct value'
-    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 1 2 sine) -- there''s only two values now'
-    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 1 2.4 sine) -- three values'
-    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 0.5 2.4 sine) -- four values'
-    - 'd1 $ s "arpy!16" # speed (quantise 2 $ range 2 2.4 sine) -- one values'
-    - 'd1 $ s "arpy!16" # speed (quantise 6 $ range 2 2.4 sine) -- three values'
-    - 'd1 $ s "arpy!32" # speed (quantise 32 $ range 2 2.4 sine) -- a lot of values'
+    - 'd1 $ s "arpy!16" # speed (saw |+| 1) -- every event has a distinct value'
+    - 'd1 $ s "arpy!16" # speed (quantise 2 $ saw |+| 1) -- there''s only two values now'
+    - 'd1 $ s "arpy!16" # speed (quantise 3 $ saw |+| 1) -- only three values'
+    - 'd1 $ s "arpy!16" # speed (quantise 3 $ saw |+| 2) -- still only three values'
+    - 'd1 $ s "arpy!16" # speed (quantise 3 $ range 1 4 saw |+| 1) -- nine values'
+    - 'd1 $ s "arpy!16" # speed (quantise 1 $ (saw |+| 1)) --one value, because saw is >=0 and <1'
+    - 'd1 $ s "arpy!16" # speed (quantise 1 $ (square |+| 1)) -- two values, because square is 0 or 1'
 euclid:
   cmd: euclid num parts cpattern
   help:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "onCommand:tidal.eval",
         "onCommand:tidal.evalMulti",
         "onCommand:tidal.hush",
+        "onCommand:tidal.codehelp.reload",
         "onCommand:tidal.shortcut.no1",
         "onCommand:tidal.shortcut.no2",
         "onCommand:tidal.shortcut.no3",
@@ -46,6 +47,10 @@
             {
                 "command": "tidal.shush",
                 "title": "Tidal Shush"
+            },
+            {
+                "command": "tidal.codehelp.reload",
+                "title": "Tidal Codehelp Reload"
             },
             {
                 "command": "tidal.shortcut",
@@ -222,6 +227,14 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Show the shortcut commands that are executed in the console. Useful for debugging."
+                },
+                "tidalcycles.codehelp.commands.extra": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Extra files to read command definitions for hover and comletion support. This will be appended to the internal file and thus override any existing definitions."
                 },
                 "tidalcycles.codehelp.hover.level": {
                     "type": "string",

--- a/src/codehelp.ts
+++ b/src/codehelp.ts
@@ -415,7 +415,7 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
         for(let i=endChar;i<=line.length;i++){
             endChar = i;
             if(i < line.length){
-                const m = line.charAt(i).match(/^[0-9a-z_]$/i);
+                const m = line.charAt(i).match(/^[0-9a-z_']$/i);
                 if(m === null || m.length === 0){
                     break;
                 }

--- a/src/codehelp.ts
+++ b/src/codehelp.ts
@@ -200,7 +200,7 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
 
         const combinedDefinitions = [
                 ...(typeof yamlCommandDefinitions === 'undefined' ? defaultSources : [])
-                , ...extraFiles
+                , ...(typeof extraFiles === 'undefined' ? [] : extraFiles)
             ].map((defPath) => {
                 try {
                     return {source: defPath, ydef: yaml.load(readFileSync(defPath).toString())};

--- a/src/codehelp.ts
+++ b/src/codehelp.ts
@@ -32,22 +32,39 @@ class TidalParameterDescription {
 }
 
 class TidalCommandDescription {
-    public readonly formattedCommand:MarkdownString;
+    public readonly command:string;
+    public readonly alias?: string;
+    public readonly formattedCommand:MarkdownString[];
     public readonly parameters:TidalParameterDescription[] | undefined;
     public readonly returns:MarkdownString | undefined;
     public readonly help:MarkdownString |  undefined;
     public readonly examples:MarkdownString[];
     public readonly links:({url:string, title:MarkdownString})[];
 
-    constructor(
-        public readonly command:string
-        , formattedCommand?:string | MarkdownString
+    constructor(config:{
+        command:string
+        , alias?:string
+        , formattedCommand?:(string | MarkdownString | ((string | MarkdownString)[]))
         , parameters?:TidalParameterDescription[]
         , returns?:string
         , help?:MarkdownString | string
-        , links:({url:string, title:string | MarkdownString})[] = []
-        , examples:string | string[] | MarkdownString | MarkdownString[] = []
-    ){
+        , links?:({url:string, title:string | MarkdownString})[]
+        , examples?:string | string[] | MarkdownString | MarkdownString[]
+    }){
+        let {
+            command
+            , alias
+            , formattedCommand
+            , parameters
+            , returns
+            , help
+            , links
+            , examples
+        } = config;
+
+        this.command = command;
+        this.alias = alias;
+
         if(typeof parameters === 'undefined'){
             this.parameters = [];
         }
@@ -64,29 +81,36 @@ class TidalCommandDescription {
                 formattedCommand = command+" ?";
             }
             else {
-                formattedCommand = command+" "+this.parameters.map(x => x.name).reduce((x,y) => x+" "+y);
+                formattedCommand = command+" "+this.parameters.map(x => x.name).join(" ");
             }
         }
         
-        if(typeof formattedCommand === 'string'){
-            if(formattedCommand.indexOf("`") < 0 || formattedCommand.indexOf("    ") !== 0){
-                formattedCommand = `    ${formattedCommand}`;
-            }
-            formattedCommand = new MarkdownString(formattedCommand);
+        if(!Array.isArray(formattedCommand)){
+            formattedCommand = [formattedCommand];
         }
-        
-        this.formattedCommand = formattedCommand;
+
+        this.formattedCommand = formattedCommand.map(cmd => {
+            if(typeof cmd === 'string'){
+                if(cmd.indexOf("`") < 0 || cmd.indexOf("    ") !== 0){
+                    cmd = `    ${cmd}`;
+                }
+                return new MarkdownString(cmd);
+            }
+            return cmd;
+        });
 
         this.parameters.forEach(p => p.help.isTrusted = true);
-        this.formattedCommand.isTrusted = true;
+        this.formattedCommand.forEach((cmd) => {cmd.isTrusted = true;});
 
+        let myReturns;
         if(typeof returns === 'undefined'){
-            this.returns = undefined;
+            myReturns = undefined;
         }
         else {
-            this.returns = typeof returns === 'string' ? new MarkdownString(returns) : returns;
-            this.returns.isTrusted = true;
+            myReturns = typeof returns === 'string' ? new MarkdownString(returns) : returns;
+            myReturns.isTrusted = true;
         }
+        this.returns = myReturns;
         
         if(typeof help === 'undefined'){
             this.help = undefined;
@@ -96,12 +120,15 @@ class TidalCommandDescription {
             this.help.isTrusted = true;
         }
 
-        this.links = links.map(link => ({
+        this.links = typeof links === 'undefined' ? [] : links.map(link => ({
             ...link
             , title: typeof link.title === 'string' ?  new MarkdownString(link.title) : link.title}
         ));
         
-        if(typeof examples === 'string'){
+        if(typeof examples === 'undefined'){
+            this.examples = [];
+        }
+        else if(typeof examples === 'string'){
             this.examples = [new MarkdownString(examples)];
         }
         else if(Array.isArray(examples)){
@@ -134,7 +161,11 @@ ${x}
         let ms = new MarkdownString("");
         ms.isTrusted = true;
         
-        ms = ms.appendMarkdown(withCommand ? this.formattedCommand.value : "");
+        ms = ms.appendMarkdown(
+            withCommand
+            ? this.formattedCommand.map(x => x.value).join("    \n")
+            : ""
+        );
         if(detailLevel === CodeHelpDetailLevel.MINIMUM){
             return ms;
         }
@@ -150,7 +181,7 @@ ${x}
                     `\`${x.name}\` `
                     + (typeof x.type !== 'undefined' ? `\`${TidalTypeDescription[x.type]}\`` : "")
                     + ` ${x.help.value}`)
-                    .reduce((x,y) => x+"    \r\n"+y,"")
+                    .join("    \r\n")
             )
             .appendMarkdown(typeof this.returns === 'undefined' ? "" :
                 "\r\n\r\n" + "Returns: "
@@ -163,7 +194,7 @@ ${x}
 
         ms = ms.appendMarkdown(this.examples.length === 0 ? "" :
                 hline + "Examples:\r\n\r\n"
-                + this.examples.map(x => x.value).reduce((x,y) => x+"    \r\n"+y,"")
+                + this.examples.map(x => x.value).join("    \r\n")
             )
             .appendMarkdown(this.links.length === 0 ? "" :
                 hline + this.links
@@ -171,7 +202,7 @@ ${x}
                         (lnk.title.value.trim() === "" ? "" : `${lnk.title.value}: `)
                         + `<${lnk.url}>`
                     )
-                    .reduce((x,y) => x+"    \r\n"+y,"")
+                    .join("    \r\n")
             );
         return ms;
     }
@@ -267,9 +298,10 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
             let parameters:TidalParameterDescription[] | undefined = undefined;
             let examples:string[] | undefined = undefined;
             let links:({url:string, title:string})[] | undefined = undefined;
-            let formattedCommand:string | undefined = undefined;
+            let formattedCommand:string[] = [];
             let help:string | undefined = undefined;
             let returns:string | undefined = undefined;
+            let alias:string | undefined = undefined;
 
             if(typeof v === 'object'){
                 Object.entries(v === null ? {} : v).map(([property, value, ..._]) => {
@@ -278,7 +310,15 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
                     }
                     if(property === 'cmd' || property === 'formattedCommand'){
                         if(typeof value === 'string'){
-                            formattedCommand = value;
+                            formattedCommand = [value];
+                        }
+                        else if(Array.isArray(value)){
+                            formattedCommand = value.filter(x => typeof x === 'string');
+                        }
+                    }
+                    else if(property === 'alias'){
+                        if(typeof value === 'string'){
+                            alias = value;
                         }
                     }
                     else if(property === 'return' || property === 'returns'){
@@ -353,7 +393,7 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
                 throw new Error("Invalid command description value type "+(typeof v));
             }
 
-            return new TidalCommandDescription(command, formattedCommand, parameters, returns, help, links, examples);
+            return new TidalCommandDescription({command, alias, formattedCommand, parameters, returns, help, links, examples});
         });
     }
 
@@ -403,23 +443,33 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
             .map(k => ({'key':k, 'cdesc':this.commandDescriptions[k]}))
             .map(({key, cdesc}) => {
                 const item = new CompletionItem(key);
+                let insertCommand = cdesc;
                 
+                if(typeof cdesc.alias !== 'undefined'){
+                    const alias = cdesc.alias;
+                    let adesc = this.commandDescriptions[alias];
+                    if(typeof adesc !== 'undefined'){
+                        cdesc = adesc;
+                    }
+                }
+
                 item.kind = CompletionItemKind.Snippet;
 
                 if(typeof cdesc !== 'undefined'){
                     item.documentation = cdesc.format(this.config.getCompletionHelpDetailLevel(), false);
                 }
                 item.range = range;
-                item.detail = cdesc.formattedCommand.value.replace(/`/g,'');
+                item.detail = cdesc.formattedCommand.map(x => x.value.replace(/`/g,'')).join("    \n");
 
                 if(typeof cdesc.parameters === 'undefined'){
                     item.detail = "Tidal code";
                 }
                 else {
-                    item.insertText = cdesc.command
-                        + cdesc.parameters.filter(x => x.editable)
-                                            .map(x => x.name)
-                                            .reduce((x,y)=>x+" "+y,"");
+                    item.insertText = insertCommand.command
+                        + (insertCommand.parameters ? insertCommand.parameters : cdesc.parameters)
+                            .filter(x => x.editable)
+                            .map(x => x.name)
+                            .join(" ");
                 }
 
                 return item;
@@ -437,12 +487,18 @@ export class TidalLanguageHelpProvider implements HoverProvider, CompletionItemP
         if(typeof word === 'undefined' || typeof range === 'undefined'){
             return undefined;
         }
-        let hoverText = this.commandDescriptions[word];
-        if(typeof hoverText === 'undefined'){
+        let commandDescription = this.commandDescriptions[word];
+        if(typeof commandDescription === 'undefined'){
             return undefined;
         }
+        if(typeof commandDescription.alias !== 'undefined'){
+            const nhover = this.commandDescriptions[commandDescription.alias];
+            if(typeof nhover !== undefined){
+                commandDescription = nhover;
+            }
+        }
 
-        const hovermd = hoverText.format(this.config.getHoverHelpDetailLevel(), true);
+        const hovermd = commandDescription.format(this.config.getHoverHelpDetailLevel(), true);
         if(typeof hovermd === 'undefined'){
             return undefined;
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,10 @@ export class Config {
         return this.getConfiguration(this.configSection).get('shortcuts.showInConsole', false);
     }
 
+    public getExtraCommandsFiles(): string[] {
+        return this.getConfiguration(this.configSection).get<string[]>("codehelp.commands.extra", []);
+    }
+
     public getHoverHelpDetailLevel(): CodeHelpDetailLevel {
         let level = this.getConfiguration(this.configSection)
             .get("codehelp.hover.level", CodeHelpDetailLevel[CodeHelpDetailLevel.FULL] as string);

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -72,8 +72,8 @@ command2:
 extracmd:
     cmd:
         - extra
-        - aliascmd
-aliascmd:
+        - aliascmd'
+aliascmd':
     alias: commandName
         `;
 
@@ -87,7 +87,7 @@ aliascmd:
 
         assert.exists(provider.commandDescriptions);
         assert.isObject(provider.commandDescriptions);
-        assert.hasAllKeys(provider.commandDescriptions, ["commandName", "command2", "extracmd", "aliascmd"]);
+        assert.hasAllKeys(provider.commandDescriptions, ["commandName", "command2", "extracmd", "aliascmd'"]);
         assert.exists(provider.commandDescriptions["commandName"].command);
         assert.exists(provider.commandDescriptions["commandName"].formattedCommand);
         assert.equal(provider.commandDescriptions["commandName"].formattedCommand.length, 1)
@@ -102,11 +102,11 @@ aliascmd:
         assert.exists(provider.commandDescriptions["extracmd"].command);
         assert.equal(provider.commandDescriptions["extracmd"].formattedCommand.length, 2);
         assert.equal(provider.commandDescriptions["extracmd"].formattedCommand[0].value, "    extra");
-        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand[1].value, "    aliascmd");
+        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand[1].value, "    aliascmd'");
         
-        assert.exists(provider.commandDescriptions["aliascmd"].command);
-        assert.equal(provider.commandDescriptions["aliascmd"].formattedCommand.length, 0);
-        assert.equal(provider.commandDescriptions["aliascmd"].alias, 'commandName');
+        assert.exists(provider.commandDescriptions["aliascmd'"].command);
+        assert.equal(provider.commandDescriptions["aliascmd'"].formattedCommand.length, 0);
+        assert.equal(provider.commandDescriptions["aliascmd'"].alias, 'commandName');
     });
 
     ["hover", "complete"].forEach(helpType => {
@@ -115,21 +115,21 @@ aliascmd:
                 {level: "FULL"
                     , contains:["    commandLine","param","paramValue"
                         ,"returnValue","link1","link2","link3","title3","exampleText"]
-                    , notContains:["commandName","aliascmd"]}
+                    , notContains:["commandName","aliascmd'"]}
                 , {level: "OFF"
                     , contains:[]
                     , notContains:["commandName","    commandLine","param","paramValue"
-                        , "returnValue","link1","link2","link3","title3","exampleText","aliascmd"]}
+                        , "returnValue","link1","link2","link3","title3","exampleText","aliascmd'"]}
                 , {level: "MINIMUM"
                     , contains:["    commandLine"]
                     , notContains:["param","paramValue"
-                        ,"returnValue","link1","link2","link3","title3","exampleText","aliascmd"]}
+                        ,"returnValue","link1","link2","link3","title3","exampleText","aliascmd'"]}
                 , {level: "NO_EXAMPLES_NO_LINKS"
                     , contains:["    commandLine","param","paramValue"
                         ,"returnValue"]
-                    , notContains:["commandName","link1","link2","link3","title3","exampleText","aliascmd"]}
+                    , notContains:["commandName","link1","link2","link3","title3","exampleText","aliascmd'"]}
             ].forEach(({level, contains, notContains}) => {
-                ["commandName", "aliascmd"].forEach(cmdname => {
+                ["commandName", "aliascmd'"].forEach(cmdname => {
                     test(`Level: ${level} / ${cmdname}`, () => {
                         const config = createMockTestConfig(level, level);
                         const provider = new TidalLanguageHelpProvider(

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -66,14 +66,20 @@ command2:
     cmd: command2
 `);
 
-    test("yaml processing", () => {
-        const extraFile = path.join(tempdir, "extra1.yaml")
-        writeFileSync(extraFile, `
+    const extraFileContent = `
 command2:
     cmd: override
 extracmd:
-    cmd: extra
-`)
+    cmd:
+        - extra
+        - aliascmd
+aliascmd:
+    alias: commandName
+        `;
+
+    test("yaml processing", () => {
+        const extraFile = path.join(tempdir, "extra1.yaml")
+        writeFileSync(extraFile, extraFileContent)
 
         const config = createMockTestConfig('FULL', 'FULL');
         config.setup(cfg => cfg.getExtraCommandsFiles()).returns(() => [extraFile]);
@@ -81,19 +87,26 @@ extracmd:
 
         assert.exists(provider.commandDescriptions);
         assert.isObject(provider.commandDescriptions);
-        assert.hasAllKeys(provider.commandDescriptions, ["commandName", "command2", "extracmd"]);
+        assert.hasAllKeys(provider.commandDescriptions, ["commandName", "command2", "extracmd", "aliascmd"]);
         assert.exists(provider.commandDescriptions["commandName"].command);
         assert.exists(provider.commandDescriptions["commandName"].formattedCommand);
-        assert.hasAllKeys(provider.commandDescriptions["commandName"].formattedCommand, ["value","isTrusted"]);
-        assert.equal(provider.commandDescriptions["commandName"].formattedCommand.value, "    commandLine");
-        assert.isTrue(provider.commandDescriptions["commandName"].formattedCommand.isTrusted);
+        assert.equal(provider.commandDescriptions["commandName"].formattedCommand.length, 1)
+        assert.hasAllKeys(provider.commandDescriptions["commandName"].formattedCommand[0], ["value","isTrusted"]);
+        assert.equal(provider.commandDescriptions["commandName"].formattedCommand[0].value, "    commandLine");
+        assert.isTrue(provider.commandDescriptions["commandName"].formattedCommand[0].isTrusted);
 
         assert.exists(provider.commandDescriptions["command2"].command);
-        assert.equal(provider.commandDescriptions["command2"].formattedCommand.value, "    override");
+        assert.equal(provider.commandDescriptions["command2"].formattedCommand.length, 1);
+        assert.equal(provider.commandDescriptions["command2"].formattedCommand[0].value, "    override");
 
         assert.exists(provider.commandDescriptions["extracmd"].command);
-        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand.value, "    extra");
+        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand.length, 2);
+        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand[0].value, "    extra");
+        assert.equal(provider.commandDescriptions["extracmd"].formattedCommand[1].value, "    aliascmd");
         
+        assert.exists(provider.commandDescriptions["aliascmd"].command);
+        assert.equal(provider.commandDescriptions["aliascmd"].formattedCommand.length, 0);
+        assert.equal(provider.commandDescriptions["aliascmd"].alias, 'commandName');
     });
 
     ["hover", "complete"].forEach(helpType => {
@@ -102,115 +115,128 @@ extracmd:
                 {level: "FULL"
                     , contains:["    commandLine","param","paramValue"
                         ,"returnValue","link1","link2","link3","title3","exampleText"]
-                    , notContains:["commandName"]}
+                    , notContains:["commandName","aliascmd"]}
                 , {level: "OFF"
                     , contains:[]
                     , notContains:["commandName","    commandLine","param","paramValue"
-                        , "returnValue","link1","link2","link3","title3","exampleText"]}
+                        , "returnValue","link1","link2","link3","title3","exampleText","aliascmd"]}
                 , {level: "MINIMUM"
                     , contains:["    commandLine"]
                     , notContains:["param","paramValue"
-                        ,"returnValue","link1","link2","link3","title3","exampleText"]}
+                        ,"returnValue","link1","link2","link3","title3","exampleText","aliascmd"]}
                 , {level: "NO_EXAMPLES_NO_LINKS"
                     , contains:["    commandLine","param","paramValue"
                         ,"returnValue"]
-                    , notContains:["commandName","link1","link2","link3","title3","exampleText"]}
+                    , notContains:["commandName","link1","link2","link3","title3","exampleText","aliascmd"]}
             ].forEach(({level, contains, notContains}) => {
-                test("Level: "+level, () => {
-                    const config = createMockTestConfig(level, level);
-                    const provider = new TidalLanguageHelpProvider(
-                        "./", config.object,
-                        [{source:"test1",ydef:testData}]
-                    );
-            
-                    const ts = new CancellationTokenSource();
-            
-                    
-                    let h;
-                    if(helpType === 'complete'){
-                        h = provider.provideCompletionItems(
-                            createMockDocument(["","    commandName arg1 arg2",""]).object
-                            , new Position(1, 5)
-                            , ts.token
-                            , TypeMoq.Mock.ofType<vscode.CompletionContext>().object
+                ["commandName", "aliascmd"].forEach(cmdname => {
+                    test(`Level: ${level} / ${cmdname}`, () => {
+                        const config = createMockTestConfig(level, level);
+                        const provider = new TidalLanguageHelpProvider(
+                            "./", config.object,
+                            [
+                                {source:"test1",ydef:testData}
+                                , {source:"extra",ydef:yaml.load(extraFileContent)}
+                            ]
                         );
-                        if(level === 'OFF'){
-                            if(typeof h === 'undefined' || h === null) {
-                                assert.notExists(h);
-                            }
-                            else if(Array.isArray(h)){
-                                assert.equal(h.length, 0);
-                            }
-                            else if(typeof h === 'object') {
-                                assert.equal((h as vscode.CompletionList).items.length, 0);
-                            }
-                            h = undefined;
-                        }
-                        else {
-                            assert.exists(h);
-                            if(Array.isArray(h)){
-                                assert.equal(h.length, 1);
-                                h = h[0];
-                            }
-                            else if(typeof h === 'object') {
-                                h = (h as vscode.CompletionList).items;
-                                assert.exists(h);
-                                assert.equal(h.length, 1);
-                                h = h[0];
+                
+                        const ts = new CancellationTokenSource();
+                
+                        let h;
+                        if(helpType === 'complete'){
+                            h = provider.provideCompletionItems(
+                                createMockDocument(["",`    ${cmdname} arg1 arg2`,""]).object
+                                , new Position(1, 5)
+                                , ts.token
+                                , TypeMoq.Mock.ofType<vscode.CompletionContext>().object
+                            );
+
+                            if(level === 'OFF'){
+                                if(typeof h === 'undefined' || h === null) {
+                                    assert.notExists(h);
+                                }
+                                else if(Array.isArray(h)){
+                                    assert.equal(h.length, 0);
+                                }
+                                else if(typeof h === 'object') {
+                                    assert.equal((h as vscode.CompletionList).items.length, 0);
+                                }
+                                h = undefined;
                             }
                             else {
-                                // we should never get here
-                                assert.isTrue(false);
-                                console.log(h);
-                                throw new Error("invalid result type");
-                            }
-                            assert.equal(h.detail, "    commandLine");
-                            assert.exists(h.documentation);
-                            h = h.documentation;
-                            assert.typeOf(h, "object");
-                            assertContents(
-                                helpType
-                                , h as MarkdownString
-                                , contains.filter(x => x !== '    commandLine')
-                                , notContains.reduce((x,y) => {x.push(y); return x;}, ["    commandLine"])
-                            );
-                        }
-
-                    }
-                    else if(helpType === 'hover') {
-                        h = provider.provideHover(
-                            createMockDocument(["","    commandName arg1 arg2",""]).object
-                            , new Position(1, 5)
-                            , ts.token
-                        );
-                        if(level === 'OFF'){
-                            assert.notExists(h);
-                            h = undefined;
-                        }
-                        else {
-                            assert.exists(h);
-                            if(typeof h !== 'undefined') {
-                                assert.isObject(h);
-                                assert.isArray(h.contents);
-                                assert.isTrue(h.contents.length > 0);
-                                assert.isObject(h.contents[0]);
+                                assert.exists(h);
+                                if(Array.isArray(h)){
+                                    assert.equal(h.length, 1);
+                                    h = h[0];
+                                }
+                                else if(typeof h === 'object') {
+                                    h = (h as vscode.CompletionList).items;
+                                    assert.exists(h);
+                                    assert.equal(h.length, 1);
+                                    h = h[0];
+                                }
+                                else {
+                                    // we should never get here
+                                    assert.isTrue(false);
+                                    console.log(h);
+                                    throw new Error("invalid result type");
+                                }
+                                assert.equal(h.detail, "    commandLine");
+                                assert.exists(h.documentation);
+                                assert.exists(h.insertText);
+                                if(h.insertText){
+                                    let s = h.insertText;
+                                    if(typeof s === 'object'){
+                                        s = s.value;
+                                    }
+                                    assert.isTrue(s.indexOf(cmdname) >= 0);
+                                }
+                                h = h.documentation;
+                                assert.typeOf(h, "object");
                                 assertContents(
                                     helpType
-                                    , h.contents[0] as MarkdownString
-                                    , contains
-                                    , notContains
+                                    , h as MarkdownString
+                                    , contains.filter(x => x !== '    commandLine')
+                                    , notContains.reduce((x,y) => {x.push(y); return x;}, ["    commandLine"])
                                 );
+                            }
 
-                                assert.exists(h.range);
-                                if(typeof h.range !== 'undefined'){
-                                    assert.equal(h.range.start.line, 1);
-                                    assert.equal(h.range.start.character, 4);
-                                    assert.equal(h.range.end.line, 1);
-                                    assert.equal(h.range.end.character, "commandName".length+h.range.start.character);
+                        }
+                        else if(helpType === 'hover') {
+                            h = provider.provideHover(
+                                createMockDocument(["",`    ${cmdname} arg1 arg2`,""]).object
+                                , new Position(1, 5)
+                                , ts.token
+                            );
+                            if(level === 'OFF'){
+                                assert.notExists(h);
+                                h = undefined;
+                            }
+                            else {
+                                assert.exists(h);
+                                if(typeof h !== 'undefined') {
+                                    assert.isObject(h);
+                                    assert.isArray(h.contents);
+                                    assert.isTrue(h.contents.length > 0);
+                                    assert.isObject(h.contents[0]);
+                                    assertContents(
+                                        helpType
+                                        , h.contents[0] as MarkdownString
+                                        , contains
+                                        , notContains
+                                    );
+
+                                    assert.exists(h.range);
+                                    if(typeof h.range !== 'undefined'){
+                                        assert.equal(h.range.start.line, 1);
+                                        assert.equal(h.range.start.character, 4);
+                                        assert.equal(h.range.end.line, 1);
+                                        assert.equal(h.range.end.character, cmdname.length+h.range.start.character);
+                                    }
                                 }
                             }
                         }
-                    }
+                    });
                 });
             });
         });

--- a/test/codehelp.test.ts
+++ b/test/codehelp.test.ts
@@ -64,7 +64,7 @@ commandName:
 
     test("yaml processing", () => {
         const config = createMockTestConfig('FULL', 'FULL');
-        const provider = new TidalLanguageHelpProvider([{source:"test1",ydef:testData}], config.object);
+        const provider = new TidalLanguageHelpProvider("./", config.object, [{source:"test1",ydef:testData}]);
 
         assert.exists(provider.commandDescriptions);
         assert.isObject(provider.commandDescriptions);
@@ -100,8 +100,8 @@ commandName:
                 test("Level: "+level, () => {
                     const config = createMockTestConfig(level, level);
                     const provider = new TidalLanguageHelpProvider(
+                        "./", config.object,
                         [{source:"test1",ydef:testData}]
-                        , config.object
                     );
             
                     const ts = new CancellationTokenSource();
@@ -232,7 +232,7 @@ commandName:
 
             const config = createMockTestConfig('FULL', 'FULL');
         
-            const provider = new TidalLanguageHelpProvider(yf, config.object);
+            const provider = new TidalLanguageHelpProvider("./", config.object, yf);
 
             ["stut","slow"].forEach(x => {
                 assert.hasAnyKeys(provider.commandDescriptions, [x], "Expected command descirption for "+x+" to be present");


### PR DESCRIPTION
In preparation for the new release I thought it might be good to have at least the basic commands covered in the help file initially. To that extent I've now written some text and examples for almost all commands that are mentioned in the [Tutorial](https://tidalcycles.org/index.php/Tutorial) and even learned a thing or two.

While writing the additional documentation I've found that there are some problems that made the process of writing it inefficient:
 * Seeing the updated documentation in effect needed a restart of vscode
 * Some commands are pretty much the same, save for an additional parameter or two (e.g. `xfade` and `xfadein`)

I've added code to overcome these two issues, that's why this commit is not only the `yaml` for the documentation.

I'd be glad if you could consider merging this before the final release @kindohm. I think the additional documentation (which won't work on it's own because the current master does not support "aliases") is well worth it.

As always, please do let me know if you see any issues that need fixing or have any other feedback.