### PR TITLE
Fix stack options

### DIFF
--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -30,9 +30,9 @@ export class Ghci implements IGhci {
         }
 
         if (this.useStack) {
-            var stackOptions = ['--silent', 'ghci', '--ghci-options', '-XOverloadedStrings'];
+            var stackOptions = ['exec', '--package', 'tidal', '--', 'ghci', '-XOverloadedStrings'];
             if (!this.showGhciOutput) {
-                stackOptions.push('--ghci-options', '-v0');
+                stackOptions.push('-v0');
             }
             this.ghciProcess = spawn('stack', stackOptions,
                 {


### PR DESCRIPTION
Hi @kindohm.

I had failed to execute a command with stack on MacOSX.
As for my thoughts, `stack ghci` might cause a problem. So, I've tried to execute `stack exec -- ghci`. This changes has been fine on my environment.

But I just started learning Haskell few days.
I'm sorry to say that it is difficult for me to judge the changes are correct.

#### Specifications

- Versions: vscode-tidalcycles 1.3.0
- Platform: MacOS Mojave 10.14.6
- Stack version: 2.1.3
- GHCi version: 8.6.5

#### Steps to Reproduce the Problem

  1. Launch SuperCollider
  2. Execute `SuperDirt.start` on SuperCollider IDE
  3. Launch VSCode
  4. Create new file with an extension of `.tidal` and write `d1 $ sound "bd"` on first line.
  5. Press `Shift + Enter` on first line.

The console output was:

```
GHCi, version 8.6.5: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /private/var/folders/4p/j3hy70397l70hnwn8x_26f7r0000gn/T/haskell-stack-ghci/2a3bbd58/ghci-script
Prelude> Prelude> Warning: GHCi | 
Warning: GHCi | <no location info>: error:
Warning: GHCi |     Could not find module ‘Sound.Tidal.Context’
Warning: GHCi |     It is not a module in the current program, or in any known package.
Warning: GHCi | 
Warning: GHCi | <interactive>:6:39: error: Not in scope: ‘oLatency’
Warning: GHCi | 
Warning: GHCi | <interactive>:6:55: error: Not in scope: ‘oAddress’
Warning: GHCi | 
Warning: GHCi | <interactive>:6:79: error: Not in scope: ‘oPort’
Warning: GHCi | 
Warning: GHCi | <interactive>:6:111: error: Not in scope: ‘cFrameTimespan’
Warning: GHCi | 
Warning: GHCi | <interactive>:21:38: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.xfadeIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:22:42: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.xfadeIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:23:42: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.histpan’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:24:39: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.wait’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:25:42: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.waitT’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:26:37: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.jump’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:27:41: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.jumpIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:28:42: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.jumpIn'’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:29:42: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.jumpMod’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:30:56: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.mortal’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:31:44: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.interpolate’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:32:48: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.interpolateIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:33:39: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.clutch’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:34:43: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.clutchIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:35:43: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.anticipate’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:36:47: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.anticipateIn’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:37:41: error:
Warning: GHCi |     Not in scope: ‘Sound.Tidal.Transition.mortalOverlay’
Warning: GHCi |     No module named ‘Sound.Tidal.Transition’ is imported.
Warning: GHCi | 
Warning: GHCi | <interactive>:56:12: error:
Warning: GHCi |     Variable not in scope: streamSetI :: t4 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:56:23: error: Variable not in scope: tidal
Warning: GHCi | 
Warning: GHCi | <interactive>:57:12: error:
Warning: GHCi |     Variable not in scope: streamSetF :: t3 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:57:23: error: Variable not in scope: tidal
Warning: GHCi | 
Warning: GHCi | <interactive>:58:12: error:
Warning: GHCi |     Variable not in scope: streamSetS :: t2 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:58:23: error: Variable not in scope: tidal
Warning: GHCi | 
Warning: GHCi | <interactive>:59:12: error:
Warning: GHCi |     Variable not in scope: streamSetI :: t1 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:59:23: error: Variable not in scope: tidal
Warning: GHCi | 
Warning: GHCi | <interactive>:60:12: error:
Warning: GHCi |     Variable not in scope: streamSetB :: t0 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:60:23: error: Variable not in scope: tidal
tidal> Warning: GHCi | 
Warning: GHCi | <interactive>:64:1: error: Variable not in scope: d1 :: t0 -> t
Warning: GHCi | 
Warning: GHCi | <interactive>:64:6: error:
Warning: GHCi |     • Variable not in scope: sound :: [Char] -> t0
Warning: GHCi |     • Perhaps you meant ‘round’ (imported from Prelude)
tidal> 
```