### PR TITLE
Ghci path check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,6 +255,11 @@
                 "delayed-stream": "~1.0.0"
             }
         },
+        "command-exists-promise": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/command-exists-promise/-/command-exists-promise-2.0.2.tgz",
+            "integrity": "sha512-T6PB6vdFrwnHXg/I0kivM3DqaCGZLjjYSOe0a5WgFKcz1sOnmOeIjnhQPXVXX3QjVbLyTJ85lJkX6lUpukTzaA=="
+        },
         "commander": {
             "version": "2.15.1",
             "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",

--- a/package.json
+++ b/package.json
@@ -386,6 +386,7 @@
         "vscode": "^1.1.30"
     },
     "dependencies": {
+        "command-exists-promise": "^2.0.2",
         "js-yaml": "^3.13.1",
         "node-wav-player": "^0.1.0",
         "split2": "^3.0.0"

--- a/src/@types/command-exists-promise/index.d.ts
+++ b/src/@types/command-exists-promise/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'command-exists-promise';

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import { homedir } from 'os';
 import * as commandExists from 'command-exists-promise';
 
-const ghciCommandName = 'ghcixxx';
+const ghciCommandName = 'ghci';
 
 /**
  * Provides an interface for sending commands to a GHCi session.
@@ -123,15 +123,15 @@ export class Ghci implements IGhci {
 
         triedPaths.push(ghciCommandName);
 
-        // 4. try another well-known path: $HOME/.ghcup/bin/ghci
-        const wellKnownPath1 = `/usr/local/bin/ghcixxx`;
+        // 4. try a well-known path: /usr/local/bin/ghcixxx
+        const wellKnownPath1 = `/usr/local/bin/ghci`;
         if (fs.existsSync(wellKnownPath1)) {
             return wellKnownPath1;
         }
 
         triedPaths.push(wellKnownPath1);
 
-        // 4. try another well-known path: $HOME/.ghcup/bin/ghci
+        // 5. try another well-known path: $HOME/.ghcup/bin/ghci
         const wellKnownPath2 = `${homedir()}.ghcup/bin/ghci`;
         if (fs.existsSync(wellKnownPath2)) {
             return wellKnownPath2;

--- a/src/ghci.ts
+++ b/src/ghci.ts
@@ -4,6 +4,11 @@ import * as vscode from 'vscode';
 import * as split2 from 'split2';
 import { EOL } from 'os';
 import { Stream } from 'stream';
+import * as fs from 'fs';
+import { homedir } from 'os';
+import * as commandExists from 'command-exists-promise';
+
+const ghciCommandName = 'ghcixxx';
 
 /**
  * Provides an interface for sending commands to a GHCi session.
@@ -21,32 +26,36 @@ export class Ghci implements IGhci {
         private logger: ILogger,
         private useStack: boolean,
         private ghciPath: string,
-        private showGhciOutput: boolean) {
-    }
+        private showGhciOutput: boolean
+    ) {}
 
-    private getGhciProcess(): ChildProcess {
+    private async getGhciProcess(): Promise<ChildProcess> {
         if (this.ghciProcess !== null) {
             return this.ghciProcess;
         }
 
         if (this.useStack) {
-            var stackOptions = ['--silent', 'ghci', '--ghci-options', '-XOverloadedStrings'];
+            var stackOptions = [
+                '--silent',
+                'ghci',
+                '--ghci-options',
+                '-XOverloadedStrings'
+            ];
             if (!this.showGhciOutput) {
                 stackOptions.push('--ghci-options', '-v0');
             }
-            this.ghciProcess = spawn('stack', stackOptions,
-                {
-                    cwd: vscode.workspace.rootPath
-                });
+            this.ghciProcess = spawn('stack', stackOptions, {
+                cwd: vscode.workspace.rootPath
+            });
         } else {
             var ghciOptions = ['-XOverloadedStrings'];
             if (!this.showGhciOutput) {
                 ghciOptions.push('-v0');
             }
-            this.ghciProcess = spawn(this.ghciPath, ghciOptions,
-                {
-                    cwd: vscode.workspace.rootPath
-                });
+            const resolvedGhciPath = await this.resolveGhciPath(this.ghciPath);
+            this.ghciProcess = spawn(resolvedGhciPath, ghciOptions, {
+                cwd: vscode.workspace.rootPath
+            });
         }
 
         this.ghciProcess.stderr.pipe(split2()).on('data', (data: any) => {
@@ -58,17 +67,86 @@ export class Ghci implements IGhci {
         return this.ghciProcess;
     }
 
-    private write(command: string) {
+    private async write(command: string) {
         try {
-            let ghciProcess = this.getGhciProcess();
+            const ghciProcess = await this.getGhciProcess();
             ghciProcess.stdin.write(command);
         } catch (e) {
-            this.logger.error(`Failed to get GHCi process: ${e}`);
+            this.logger.error(`${e}`);
             return;
         }
     }
 
-    public writeLn(command: string) {
-        this.write(`${command}${EOL}`);
+    public async writeLn(command: string) {
+        await this.write(`${command}${EOL}`);
+    }
+
+    private async resolveGhciPath(userPath: string) {
+        /*
+        1. Try to use user's configured path
+            - expand ~ to home directory if present
+        2. If that doesn't exist, check for user's configured path on PATH
+        3. If it doesn't exist, look for ghci on PATH
+        4. If it doesn't exist, look for ghci in other known locations:
+            - $HOME/.ghcup/bin/ghci
+        5. If that doesn't exist, throw error.
+        */
+
+        const triedPaths = [];
+
+        // 1. try to use user's configured path, if it exists
+        if (userPath && userPath !== ghciCommandName) {
+            const fullGhciPath = userPath.startsWith('~')
+                ? `${homedir()}${userPath}`
+                : userPath;
+
+            if (fs.existsSync(fullGhciPath)) {
+                return fullGhciPath;
+            }
+        }
+
+        // 2. look for user's configured value on PATH
+        if (await commandExists(userPath)) {
+            return userPath;
+        }
+
+        this.showWarning(`Configured GHCI path was not found: ${userPath}`);
+        triedPaths.push(userPath);
+
+        // 3. look for GHCI on PATH
+        if (
+            userPath !== ghciCommandName &&
+            (await commandExists(ghciCommandName))
+        ) {
+            return ghciCommandName;
+        }
+
+        triedPaths.push(ghciCommandName);
+
+        // 4. try another well-known path: $HOME/.ghcup/bin/ghci
+        const wellKnownPath1 = `/usr/local/bin/ghcixxx`;
+        if (fs.existsSync(wellKnownPath1)) {
+            return wellKnownPath1;
+        }
+
+        triedPaths.push(wellKnownPath1);
+
+        // 4. try another well-known path: $HOME/.ghcup/bin/ghci
+        const wellKnownPath2 = `${homedir()}.ghcup/bin/ghci`;
+        if (fs.existsSync(wellKnownPath2)) {
+            return wellKnownPath2;
+        }
+
+        triedPaths.push(wellKnownPath2);
+
+        const pathsString = triedPaths.join(', ');
+
+        throw vscode.FileSystemError.FileNotFound(
+            `GHCI path could not be found. Attempted paths: ${pathsString}`
+        );
+    }
+
+    private showWarning(message: string) {
+        vscode.window.showWarningMessage(message);
     }
 }

--- a/src/tidal.ts
+++ b/src/tidal.ts
@@ -7,7 +7,10 @@ import { homedir } from 'os';
  * Provides an interface to send instructions to the current Tidal instance.
  */
 export interface ITidal {
-    sendTidalExpression(expression: string, echoCommandToLogger?: boolean): Promise<void>;
+    sendTidalExpression(
+        expression: string,
+        echoCommandToLogger?: boolean
+    ): Promise<void>;
 }
 
 export class Tidal implements ITidal {
@@ -51,8 +54,8 @@ export class Tidal implements ITidal {
         } else if (bootTidalPath) {
             // expand '~' to home directory if present as first character
             const bootTidalPathExpanded = bootTidalPath.startsWith('~')
-                    ? homedir() + bootTidalPath.substring(1)
-                    : bootTidalPath;
+                ? homedir() + bootTidalPath.substring(1)
+                : bootTidalPath;
             uri = vscode.Uri.file(`${bootTidalPathExpanded}`);
         }
 
@@ -66,29 +69,32 @@ export class Tidal implements ITidal {
         }
 
         for (const command of bootCommands) {
-            this.ghci.writeLn(command);
+            await this.ghci.writeLn(command);
         }
 
         this.tidalBooted = true;
         return true;
     }
 
-    public async sendTidalExpression(expression: string, echoCommandToLogger: boolean=false) {
+    public async sendTidalExpression(
+        expression: string,
+        echoCommandToLogger: boolean = false
+    ) {
         if (!(await this.bootTidal())) {
             this.logger.error('Could not boot Tidal');
             return;
         }
 
-        this.ghci.writeLn(':{');
+        await this.ghci.writeLn(':{');
         const splits = expression.split(/[\r\n]+/);
         for (let i = 0; i < splits.length; i++) {
             const line = splits[i];
-            if(echoCommandToLogger){
+            if (echoCommandToLogger) {
                 this.logger.log(line);
             }
-            this.ghci.writeLn(line);
+            await this.ghci.writeLn(line);
         }
-        this.ghci.writeLn(':}');
+        await this.ghci.writeLn(':}');
     }
 
     private async getBootCommandsFromFile(
@@ -134,7 +140,7 @@ export class Tidal implements ITidal {
         '    waitT i f t = transition tidal True (Sound.Tidal.Transition.waitT f t) i',
         '    jump i = transition tidal True (Sound.Tidal.Transition.jump) i',
         '    jumpIn i t = transition tidal True (Sound.Tidal.Transition.jumpIn t) i',
-        '    jumpIn\' i t = transition tidal True (Sound.Tidal.Transition.jumpIn\' t) i',
+        "    jumpIn' i t = transition tidal True (Sound.Tidal.Transition.jumpIn' t) i",
         '    jumpMod i t = transition tidal True (Sound.Tidal.Transition.jumpMod t) i',
         '    mortal i lifespan release = transition tidal True (Sound.Tidal.Transition.mortal lifespan release) i',
         '    interpolate i = transition tidal True (Sound.Tidal.Transition.interpolate) i',
@@ -146,7 +152,7 @@ export class Tidal implements ITidal {
         '    forId i t = transition tidal False (Sound.Tidal.Transition.mortalOverlay t) i',
         '    d1 = p 1 . (|< orbit 0)',
         '    d2 = p 2 . (|< orbit 1)',
-        '    d3 = p 3 . (|< orbit 2)', 
+        '    d3 = p 3 . (|< orbit 2)',
         '    d4 = p 4 . (|< orbit 3)',
         '    d5 = p 5 . (|< orbit 4)',
         '    d6 = p 6 . (|< orbit 5)',


### PR DESCRIPTION
fixes #23. This feature enhances the way that the extension looks for the user's `ghci` command:

1. Try to use user's configured path in their settings
    - expand "~" to home directory, if used
2. If that doesn't exist, check for user's configured command on PATH
3. If that doesn't exist, look for ghci on PATH
4. If that doesn't exist, look for ghci in other known locations:
    - /usr/local/bin/ghci
    - $HOME/.ghcup/bin/ghci
5. If that doesn't exist, throw error.

Errors are displayed in a VSCode pop-up and also in the TidalCycles output window:

<img width="1792" alt="Screen Shot 2019-10-18 at 11 55 17 AM" src="https://user-images.githubusercontent.com/9797/67117705-fba1de80-f1a8-11e9-8012-e427b82dcae4.png">
