### PR TITLE
Use `when` clauses to avoid keybinding conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,15 +143,18 @@
         "keybindings": [
             {
                 "command": "tidal.eval",
-                "key": "Shift+Enter"
+                "key": "Shift+Enter",
+                "when": "resourceExtname == '.tidal'"
             },
             {
                 "command": "tidal.evalMulti",
-                "key": "Ctrl+Enter"
+                "key": "Ctrl+Enter",
+                "when": "resourceExtname == '.tidal'"
             },
             {
                 "command": "tidal.hush",
-                "key": "Ctrl+Alt+H"
+                "key": "Ctrl+Alt+H",
+                "when": "resourceExtname == '.tidal'"
             },
             {
                 "command": "tidalcycles.sounds.play",


### PR DESCRIPTION
Addresses #26 and #35 by adding the condition `resourceExtname == '.tidal'` to the eval & hush keybindings. This change prevents these keybindings from interfering with other VSCode extensions (such as <kbd>Shift</kbd>+<kbd>Enter</kbd> for Python & Jupyter).

I first considered the alternative condition `editorLangId == 'haskell'`. This also worked fine, but given that
- we don't assume that the Haskell language extension is installed and thus don't associate `.tidal` files with Haskell by default, and
- the user might want the keybindings to do something else when editing non-Tidal Haskell (as in e.g. [this extension](https://marketplace.visualstudio.com/items?itemName=dramforever.vscode-ghc-simple)),

I decided to rely on the file extension instead. This also seemed more straightforward than creating a custom language ID for Tidal, as discussed in #26, though there might be tradeoffs I haven't considered.

Tested locally by packaging with [vsce](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#vsce) and installing in VSCode.

![image](https://user-images.githubusercontent.com/99575/209983305-4a5b7160-443b-4d41-a1cf-7d903ef781c1.png)
