### PR TITLE
use vscode's built in info/error display

### DIFF
--- a/src/getGhciBasePath.ts
+++ b/src/getGhciBasePath.ts
@@ -1,18 +1,18 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as config from './config';
-import { writeLine } from './logger';
+import { info } from './logger';
 
 export const getGhciBasePath = () => {
-    const configuredPath = config.ghciPath();
+  const configuredPath = config.ghciPath();
 
-    if (configuredPath && configuredPath.trim().length > 0) {
-        writeLine(`custom GHCI base path configured at ${configuredPath}`);
-        const resolvedPath = configuredPath.replace('~', os.homedir());
-        return resolvedPath.endsWith('ghci')
-            ? resolvedPath.substring(0, resolvedPath.length - 4)
-            : resolvedPath;
-    }
+  if (configuredPath && configuredPath.trim().length > 0) {
+    info(`custom GHCI base path configured at ${configuredPath}`);
+    const resolvedPath = configuredPath.replace('~', os.homedir());
+    return resolvedPath.endsWith('ghci')
+      ? resolvedPath.substring(0, resolvedPath.length - 4)
+      : resolvedPath;
+  }
 
-    return path.join(os.homedir(), '.ghcup', 'bin');
+  return path.join(os.homedir(), '.ghcup', 'bin');
 };

--- a/src/getTidalBootPath.ts
+++ b/src/getTidalBootPath.ts
@@ -1,6 +1,6 @@
 import { workspace } from 'vscode';
 import * as config from './config';
-import { writeLine } from './logger';
+import { info } from './logger';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getGhciBasePath } from './getGhciBasePath';
@@ -13,14 +13,12 @@ export const getTidalBootPath = () => {
 
   // first, check for a configured boot path
   if (configuredBootTidalPath) {
-    writeLine(
-      `Custom Tidal boot path is configured: ${configuredBootTidalPath}`
-    );
+    info(`Custom Tidal boot path is configured: ${configuredBootTidalPath}`);
 
     return configuredBootTidalPath;
   }
 
-  writeLine('Custom Tidal boot path is not configured');
+  info('Custom Tidal boot path is not configured\n');
 
   // next, check for a BootTidal.hs file in the local dir
   if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
@@ -30,10 +28,10 @@ export const getTidalBootPath = () => {
     );
     try {
       fs.statSync(localBootFilePath);
-      writeLine(`Local Tidal boot file was found: ${localBootFilePath}`);
+      info(`Local Tidal boot file was found: ${localBootFilePath}`);
       return localBootFilePath;
     } catch (err) {
-      writeLine(`Local Tidal boot file was not found.`);
+      info(`Local Tidal boot file was not found.`);
     }
   }
 
@@ -48,8 +46,6 @@ export const getTidalBootPath = () => {
 
   const packagePath = path.join(dataDir, bootTidalFileName);
 
-  writeLine(
-    `Using default Tidal boot file from package path: "${packagePath}"`
-  );
+  info(`Using default Tidal boot file from package path: "${packagePath}"`);
   return packagePath;
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,20 +1,20 @@
-import { OutputChannel, window } from 'vscode';
+import { LogOutputChannel, window } from 'vscode';
 
-let outputChannel: OutputChannel;
+let outputChannel: LogOutputChannel;
 
 const getOutputChannel = () => {
-    if (!outputChannel) {
-        outputChannel = window.createOutputChannel('TidalCycles');
-        outputChannel.show();
-    }
+  if (!outputChannel) {
+    outputChannel = window.createOutputChannel('TidalCycles', { log: true });
+    outputChannel.show();
+  }
 
-    return outputChannel;
+  return outputChannel;
 };
 
-export const write = (message: string) => {
-    getOutputChannel().append(message);
+export const info = (message: string) => {
+  getOutputChannel().append(message);
 };
 
-export const writeLine = (message: string) => {
-    write(`${message}\n`);
+export const error = (message: string) => {
+  getOutputChannel().error(message);
 };

--- a/test/getGhciBasePath.test.ts
+++ b/test/getGhciBasePath.test.ts
@@ -33,7 +33,7 @@ describe('getGhciBasePath', () => {
   });
 
   it('should return configured path', () => {
-    sandbox.stub(logger, 'writeLine');
+    sandbox.stub(logger, 'info');
     sandbox.stub(config, 'ghciPath').returns('/path/to/my/stuff');
 
     const actual = getGhciBasePath();
@@ -41,7 +41,7 @@ describe('getGhciBasePath', () => {
   });
 
   it('should remove "ghci" from end of configured path', () => {
-    sandbox.stub(logger, 'writeLine');
+    sandbox.stub(logger, 'info');
     sandbox.stub(config, 'ghciPath').returns('/path/to/my/stuff/ghci');
 
     const actual = getGhciBasePath();

--- a/test/getTidalBootPath.test.ts
+++ b/test/getTidalBootPath.test.ts
@@ -21,7 +21,7 @@ describe('getTidalBootPath', () => {
   const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
-    sandbox.stub(logger, 'writeLine');
+    sandbox.stub(logger, 'info');
     sandbox.mock(vscode.workspace);
   });
 


### PR DESCRIPTION
VSCode has a `LogOutputPanel` which lets you log different levels of information (info, error, warning, etc).   

Makes output formatting a lot neater.

<img width="1659" alt="image" src="https://github.com/user-attachments/assets/0d395748-fb7b-4214-b60d-f7594b9436b1" />
